### PR TITLE
chore: switch to es-concat-stream

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,8 +43,7 @@
       "name": "@archiver/tar-stream",
       "version": "0.0.9",
       "devDependencies": {
-        "@types/concat-stream": "2.0.3",
-        "concat-stream": "2.0.0",
+        "es-concat-stream": "0.1.0",
         "tsdown": "catalog:",
       },
     },
@@ -219,8 +218,6 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@types/concat-stream": ["@types/concat-stream@2.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-3qe4oQAPNwVNwK4C9c8u+VJqv9kez+2MR4qJpoPFfXtgxxif1QbFusvXzK0/Wra2VX07smostI2VMmJNSpZjuQ=="],
-
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
@@ -237,21 +234,19 @@
 
     "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
 
-    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
-
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
-    "concat-stream": ["concat-stream@2.0.0", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.0.2", "typedarray": "^0.0.6" } }, "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A=="],
-
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "dts-resolver": ["dts-resolver@3.0.0", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q=="],
 
     "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
+
+    "es-concat-stream": ["es-concat-stream@0.1.0", "", {}, "sha512-3XELFn+l+Vpj9jcBTUr9QIHtxP5teejcab66dN9IXrV4A74qfJt7uiwEa0hkfKV+b5Y3Q29du6rdN8MN/6Yvgg=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -262,8 +257,6 @@
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
     "import-without-cache": ["import-without-cache@0.4.0", "", {}, "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ=="],
-
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -293,13 +286,9 @@
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.25.1", "", { "dependencies": { "@babel/generator": "8.0.0-rc.5", "@babel/helper-validator-identifier": "8.0.0-rc.5", "@babel/parser": "8.0.0-rc.4", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-zK82aC/8z1iVW+g0bCnlQZq04Y5bNeL/RcRwTYBwsnU6wH0N+6vpIFkN7JC0kYRS5qKA+pxQyfIPvXJ6Q5xSpQ=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
     "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
     "stream-bench": ["stream-bench@0.1.2", "", { "dependencies": { "readable-stream": "0.2.0" } }, "sha512-TAEBNwsTSO5/25ZOuH6LglxgFDjoyjXsW6vPSr9xN2kdIJrPGjR2Kfarx+ScTKV8OD9ar4v/m6QxOOw+PMxjbA=="],
-
-    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "tar": ["tar@7.5.16", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w=="],
 
@@ -315,20 +304,14 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
-
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
-    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yauzl": ["yauzl@3.3.2", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-Md9ankxxN23wncAN8s7+Tn3Co52zLUPMtnrLAbVCnfG5d2tKBFfmygYSgXlqFgXObtzIgqkx7aNgDBpso9+4qA=="],
-
-    "concat-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
   }
 }

--- a/packages/readdir-glob/src/index.ts
+++ b/packages/readdir-glob/src/index.ts
@@ -158,9 +158,9 @@ async function* exploreWalkAsync(
   const files = await readdir(path + dir, strict);
   for (const file of files) {
     const name: string = file.name;
-    const filename = dir + "/" + name;
+    const filename = `${dir}/${name}`;
     const relative = filename.slice(1); // Remove the leading /
-    const absolute = path + "/" + relative;
+    const absolute = `${path}/${relative}`;
     let stat: Stat = file;
     if (useStat || followSymlinks) {
       stat = (await getStat(absolute, followSymlinks)) ?? stat;

--- a/packages/readdir-glob/tests/absolute.test.ts
+++ b/packages/readdir-glob/tests/absolute.test.ts
@@ -7,11 +7,11 @@ import bashResults from "./bash-results.json";
 
 describe("absolute", () => {
   beforeEach(() => {
-    process.chdir(__dirname + "/fixtures");
+    process.chdir(`${__dirname}/fixtures`);
   });
 
   [true, false].forEach(function (mark) {
-    it("Emits absolute matches if option set, mark=" + mark, function (done) {
+    it(`Emits absolute matches if option set, mark=${mark}`, function (done) {
       const pattern = "a/b/**";
       const g = glob(".", { pattern });
 

--- a/packages/readdir-glob/tests/bash-comparison.test.ts
+++ b/packages/readdir-glob/tests/bash-comparison.test.ts
@@ -18,7 +18,7 @@ function cleanResults(m: string[]) {
 
 describe("bash-comparison", () => {
   beforeEach(() => {
-    process.chdir(__dirname + "/fixtures");
+    process.chdir(`${__dirname}/fixtures`);
   });
 
   ["a/{b,c,d,e,f}/**/g"].forEach((pattern) => {

--- a/packages/readdir-glob/tests/cwd-test.test.ts
+++ b/packages/readdir-glob/tests/cwd-test.test.ts
@@ -5,7 +5,7 @@ import glob from "@archiver/readdir-glob";
 
 describe("cwd-test", () => {
   beforeEach(() => {
-    process.chdir(__dirname + "/fixtures");
+    process.chdir(`${__dirname}/fixtures`);
   });
 
   it('changing cwd and searching for **/d, "."', (done) => {

--- a/packages/readdir-glob/tests/enotsup.test.ts
+++ b/packages/readdir-glob/tests/enotsup.test.ts
@@ -6,7 +6,7 @@ import glob from "@archiver/readdir-glob";
 
 describe.todo("enotsup", () => {
   beforeEach(() => {
-    process.chdir(__dirname + "/fixtures");
+    process.chdir(`${__dirname}/fixtures`);
     const readdir = fs.readdir;
     spyOn(fs, "readdir").mockImplementation(function (p, opts, cb) {
       if (

--- a/packages/readdir-glob/tests/extglob-dotfile.test.ts
+++ b/packages/readdir-glob/tests/extglob-dotfile.test.ts
@@ -11,7 +11,7 @@ import glob from "@archiver/readdir-glob";
  */
 describe("extglob-dotfile", () => {
   it("positive extglob @(.y) should match the explicit dotfile segment with dot:false", (done) => {
-    process.chdir(__dirname + "/fixtures");
+    process.chdir(`${__dirname}/fixtures`);
 
     glob(".", { pattern: "a/x/@(.y)/b", dot: false }, (er, res) => {
       expect(er).toBeFalsy();

--- a/packages/readdir-glob/tests/follow.test.ts
+++ b/packages/readdir-glob/tests/follow.test.ts
@@ -6,7 +6,7 @@ const win32 = process.platform === "win32";
 
 describe("follow", () => {
   beforeEach(() => {
-    process.chdir(__dirname + "/fixtures");
+    process.chdir(`${__dirname}/fixtures`);
   });
 
   it.skipIf(win32)("follow symlinks", (done) => {

--- a/packages/readdir-glob/tests/ignore.test.ts
+++ b/packages/readdir-glob/tests/ignore.test.ts
@@ -307,7 +307,7 @@ describe("ignore", () => {
     opt.ignore = ignore;
 
     it(name, (done) => {
-      process.chdir(__dirname + "/fixtures");
+      process.chdir(`${__dirname}/fixtures`);
 
       glob(opt.cwd || ".", { ...opt, pattern }, (er, res) => {
         expect(er).toBeFalsy();

--- a/packages/tar-stream/package.json
+++ b/packages/tar-stream/package.json
@@ -22,8 +22,7 @@
     "prepublishOnly": "bun run build"
   },
   "devDependencies": {
-    "@types/concat-stream": "2.0.3",
-    "concat-stream": "2.0.0",
+    "es-concat-stream": "0.1.0",
     "tsdown": "catalog:"
   },
   "engines": {

--- a/packages/tar-stream/src/lib/streamx.ts
+++ b/packages/tar-stream/src/lib/streamx.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import type * as nodestream from "node:stream";
 
 const STREAM_DESTROYED = new Error("Stream was destroyed");
 
@@ -265,7 +266,7 @@ interface StreamOptions {
   predestroy?(): void;
 }
 
-class Stream extends EventEmitter {
+class Stream extends EventEmitter implements nodestream.Stream {
   _duplexState: number;
   _readableState: ReadableState | null;
   _writableState: WritableState | null;
@@ -340,6 +341,10 @@ class Stream extends EventEmitter {
       if (this._readableState !== null) this._readableState.updateNextTick();
       if (this._writableState !== null) this._writableState.updateNextTick();
     }
+  }
+
+  pipe<T extends NodeJS.WritableStream>(destination: T): T {
+    return destination;
   }
 }
 
@@ -622,7 +627,7 @@ interface ReadableOptions extends StreamOptions, ReadableStateOptions {
   read(callback: (err: Error | null) => void): void;
 }
 
-class Readable extends Stream {
+class Readable extends Stream implements nodestream.Readable {
   constructor(opts?: Partial<ReadableOptions>) {
     super(opts);
 
@@ -656,7 +661,10 @@ class Readable extends Stream {
     callback(null);
   }
 
-  pipe(dest: Writable, callback?: (err: Error | null) => void): Writable {
+  pipe(
+    dest: nodestream.Writable,
+    callback?: (err: Error | null) => void,
+  ): Writable {
     this._readableState.updateNextTick();
     this._readableState.pipe(dest, callback);
     return dest;
@@ -770,7 +778,7 @@ interface WritableOptions extends StreamOptions, WritableStateOptions {
   eagerOpen?: boolean;
 }
 
-class Writable extends Stream {
+class Writable extends Stream implements nodestream.Writable {
   constructor(opts?: WritableOptions) {
     super(opts);
 
@@ -798,7 +806,7 @@ class Writable extends Stream {
     callback(null);
   }
 
-  _write(data: Buffer, callback: (err?: Error) => void): void {
+  _write(data: Buffer, callback: (err?: Error | null) => void): void {
     this._writableState.autoBatch(data, callback);
   }
 

--- a/packages/tar-stream/src/lib/streamx.ts
+++ b/packages/tar-stream/src/lib/streamx.ts
@@ -661,10 +661,10 @@ class Readable extends Stream implements nodestream.Readable {
     callback(null);
   }
 
-  pipe(
-    dest: nodestream.Writable,
+  pipe<T extends nodestream.Writable>(
+    dest: T,
     callback?: (err: Error | null) => void,
-  ): Writable {
+  ): T {
     this._readableState.updateNextTick();
     this._readableState.pipe(dest, callback);
     return dest;
@@ -1095,7 +1095,10 @@ class ReadableState {
     return (this.stream._duplexState & READ_DONE) !== 0;
   }
 
-  pipe(pipeTo: Writable, callback?: (err: Error | null) => void): void {
+  pipe<T extends nodestream.Writable>(
+    pipeTo: T,
+    callback?: ((err: Error | null) => void) | null,
+  ): void {
     if (this.pipeTo !== null) {
       throw new Error("Can only pipe to one destination");
     }

--- a/packages/tar-stream/tests/extract.test.ts
+++ b/packages/tar-stream/tests/extract.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test";
 import * as fs from "node:fs";
 
-import concat from "concat-stream";
+import concat from "es-concat-stream";
 
 import * as tar from "../src/index.js";
 import * as fixtures from "./fixtures";
@@ -80,7 +80,7 @@ test("chunked-one-file", function () {
   const b = fs.readFileSync(fixtures.ONE_FILE_TAR);
 
   for (let i = 0; i < b.length; i += 321) {
-    extract.write(b.subarray(i, clamp(i + 321, b.length, b.length)));
+    extract.write(b.subarray(i, clamp(i + 321, b.length)));
   }
   extract.end();
 });
@@ -97,7 +97,7 @@ test("multi-file", function () {
 
   extract.end(fs.readFileSync(fixtures.MULTI_FILE_TAR));
 
-  function onfile1(header, stream, cb) {
+  function onfile1(header: unknown, stream, cb) {
     expect(header).toEqual({
       name: "file-1.txt",
       mode: 0o644,
@@ -123,7 +123,7 @@ test("multi-file", function () {
     );
   }
 
-  function onfile2(header, stream, cb) {
+  function onfile2(header: unknown, stream, cb) {
     expect(header).toEqual({
       name: "file-2.txt",
       mode: 0o644,
@@ -162,11 +162,11 @@ test("chunked-multi-file", function () {
 
   const b = fs.readFileSync(fixtures.MULTI_FILE_TAR);
   for (let i = 0; i < b.length; i += 321) {
-    extract.write(b.subarray(i, clamp(i + 321, b.length, b.length)));
+    extract.write(b.subarray(i, clamp(i + 321, b.length)));
   }
   extract.end();
 
-  function onfile1(header, stream, cb) {
+  function onfile1(header: unknown, stream, cb) {
     expect(header).toEqual({
       name: "file-1.txt",
       mode: 0o644,
@@ -721,7 +721,7 @@ test("unknown format attempts to extract if allowed", function () {
 
   extract.end(fs.readFileSync(fixtures.UNKNOWN_FORMAT));
 
-  function onfile1(header, stream, cb) {
+  function onfile1(header: unknown, stream, cb) {
     expect(header).toEqual({
       name: "file-1.txt",
       mode: 0o644,
@@ -747,7 +747,7 @@ test("unknown format attempts to extract if allowed", function () {
     );
   }
 
-  function onfile2(header, stream, cb) {
+  function onfile2(header: unknown, stream, cb) {
     expect(header).toEqual({
       name: "file-2.txt",
       mode: 0o644,
@@ -832,8 +832,7 @@ test("async iterator - explicit throw calls destroy", async function () {
   expect(extract.destroyed).toBeTrue();
 });
 
-function clamp(index, len, defaultValue) {
-  if (typeof index !== "number") return defaultValue;
+function clamp(index: number, len: number) {
   index = ~~index; // Coerce to integer.
   if (index >= len) return len;
   if (index >= 0) return index;

--- a/packages/tar-stream/tests/extract.test.ts
+++ b/packages/tar-stream/tests/extract.test.ts
@@ -192,7 +192,7 @@ test("chunked-multi-file", function () {
     );
   }
 
-  function onfile2(header, stream, cb) {
+  function onfile2(header: unknown, stream, cb) {
     expect(header).toEqual({
       name: "file-2.txt",
       mode: 0o644,
@@ -268,7 +268,7 @@ test("types", function () {
 
   extract.end(fs.readFileSync(fixtures.TYPES_TAR));
 
-  function ondir(header, stream, cb) {
+  function ondir(header: unknown, stream, cb) {
     expect(header).toEqual({
       name: "directory",
       mode: 0o755,
@@ -294,7 +294,7 @@ test("types", function () {
     cb();
   }
 
-  function onlink(header, stream, cb) {
+  function onlink(header: unknown, stream, cb) {
     expect(header).toEqual({
       name: "directory-link",
       mode: 0o755,

--- a/packages/tar-stream/tests/pack.test.ts
+++ b/packages/tar-stream/tests/pack.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "bun:test";
 import * as fs from "node:fs";
 
-import concat from "concat-stream";
+import concat from "es-concat-stream";
 
 import * as tar from "../src/index";
 import { Writable } from "../src/lib/streamx";

--- a/packages/tar-stream/tsconfig.json
+++ b/packages/tar-stream/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./"
+    "rootDir": "."
   },
   "include": ["src", "tests"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies in tar-stream package, replacing concat-stream with es-concat-stream.
  * Updated TypeScript configuration for improved consistency.

* **Refactor**
  * Improved code consistency across test files and source code with updated path construction patterns.
  * Enhanced stream interface implementations for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->