### PR TITLE
chore: rewrite tests from "bun:test" to "node:test"

### DIFF
--- a/packages/archiver/tests/archiver.test.ts
+++ b/packages/archiver/tests/archiver.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import assert from "node:assert/strict";
 import {
   createWriteStream,
   chmodSync,
@@ -10,6 +10,7 @@ import {
   mkdirSync,
 } from "node:fs";
 import { Readable } from "node:stream";
+import { describe, it, before, after } from "node:test";
 
 import { JsonArchive } from "../src/index.js";
 import { normalizeEntryData } from "../src/lib/core.js";
@@ -20,7 +21,7 @@ const testDate = new Date("Jan 03 2013 14:26:38 GMT");
 const win32 = process.platform === "win32";
 
 describe("archiver", () => {
-  beforeAll(() => {
+  before(() => {
     mkdirSync("tmp", { recursive: true });
     if (!win32) {
       chmodSync("tests/fixtures/executable.sh", 511); // 0777
@@ -42,7 +43,7 @@ describe("archiver", () => {
     }
   });
 
-  afterAll(() => {
+  after(() => {
     unlinkSync("tests/fixtures/directory/subdir/level0link.txt");
     unlinkSync("tests/fixtures/directory/subdir/subsublink");
   });
@@ -54,13 +55,13 @@ describe("archiver", () => {
           name: "entry.txt",
           prefix: "prefix/",
         });
-        expect(prefix1).toHaveProperty("name", "prefix/entry.txt");
+        assert.strictEqual(prefix1.name, "prefix/entry.txt");
 
         const prefix2 = normalizeEntryData({
           name: "entry.txt",
           prefix: "",
         });
-        expect(prefix2).toHaveProperty("name", "entry.txt");
+        assert.strictEqual(prefix2.name, "entry.txt");
       });
 
       it("should support special bits on unix", () => {
@@ -69,7 +70,7 @@ describe("archiver", () => {
             name: "executable.sh",
             mode: statSync("tests/fixtures/executable.sh").mode,
           });
-          expect(mode).toHaveProperty("mode", 511);
+          assert.strictEqual(mode.mode, 511);
         }
       });
     });
@@ -79,26 +80,28 @@ describe("archiver", () => {
     describe("#abort", () => {
       let archive: JsonArchive;
 
-      beforeAll((done) => {
+      before(async () => {
         archive = new JsonArchive();
-        const testStream = createWriteStream("tmp/abort.json");
-        testStream.on("close", () => {
-          done();
+        await new Promise<void>((resolve) => {
+          const testStream = createWriteStream("tmp/abort.json");
+          testStream.on("close", () => {
+            resolve();
+          });
+          archive.pipe(testStream);
+          archive
+            .append(testBuffer, { name: "buffer.txt", date: testDate })
+            .append(createReadStream("tests/fixtures/test.txt"), {
+              name: "stream.txt",
+              date: testDate,
+            })
+            .file("tests/fixtures/test.txt")
+            .abort();
         });
-        archive.pipe(testStream);
-        archive
-          .append(testBuffer, { name: "buffer.txt", date: testDate })
-          .append(createReadStream("tests/fixtures/test.txt"), {
-            name: "stream.txt",
-            date: testDate,
-          })
-          .file("tests/fixtures/test.txt")
-          .abort();
       });
 
       it("should have a state of aborted", () => {
-        expect(archive).toHaveProperty("_state");
-        expect(archive._state).toHaveProperty("aborted", true);
+        assert.ok("_state" in archive);
+        assert.strictEqual(archive._state.aborted, true);
       });
     });
 
@@ -107,183 +110,177 @@ describe("archiver", () => {
       let archive: JsonArchive;
       const entries = {};
 
-      beforeAll((done) => {
+      before(async () => {
         archive = new JsonArchive();
-        const testStream = createWriteStream("tmp/append.json");
-        testStream.on("close", () => {
-          actual = readJSON("tmp/append.json");
-          actual.forEach((entry) => {
-            entries[entry.name] = entry;
+        await new Promise<void>((resolve) => {
+          const testStream = createWriteStream("tmp/append.json");
+          testStream.on("close", () => {
+            actual = readJSON("tmp/append.json");
+            actual.forEach((entry) => {
+              entries[entry.name] = entry;
+            });
+            resolve();
           });
-          done();
+          archive.pipe(testStream);
+          archive
+            .append(testBuffer, { name: "buffer.txt", date: testDate })
+            .append(createReadStream("tests/fixtures/test.txt"), {
+              name: "stream.txt",
+              date: testDate,
+            })
+            .append(Readable.from(["test"]), {
+              name: "stream-like.txt",
+              date: testDate,
+            })
+            .append(null, { name: "directory/", date: testDate })
+            .finalize();
         });
-        archive.pipe(testStream);
-        archive
-          .append(testBuffer, { name: "buffer.txt", date: testDate })
-          .append(createReadStream("tests/fixtures/test.txt"), {
-            name: "stream.txt",
-            date: testDate,
-          })
-          .append(Readable.from(["test"]), {
-            name: "stream-like.txt",
-            date: testDate,
-          })
-          .append(null, { name: "directory/", date: testDate })
-          .finalize();
       });
 
       it("should append multiple entries", () => {
-        expect(Array.isArray(actual)).toBe(true);
-        expect(actual).toHaveLength(4);
+        assert.ok(Array.isArray(actual));
+        assert.strictEqual(actual.length, 4);
       });
 
       it("should append buffer", () => {
-        expect(entries).toHaveProperty(["buffer.txt"]);
-        expect(entries["buffer.txt"]).toHaveProperty("name", "buffer.txt");
-        expect(entries["buffer.txt"]).toHaveProperty("type", "file");
-        expect(entries["buffer.txt"]).toHaveProperty(
-          "date",
+        assert.ok("buffer.txt" in entries);
+        assert.strictEqual(entries["buffer.txt"].name, "buffer.txt");
+        assert.strictEqual(entries["buffer.txt"].type, "file");
+        assert.strictEqual(
+          entries["buffer.txt"].date,
           "2013-01-03T14:26:38.000Z",
         );
-        expect(entries["buffer.txt"]).toHaveProperty("mode", 420);
-        expect(entries["buffer.txt"]).toHaveProperty("crc32", 3893830384);
-        expect(entries["buffer.txt"]).toHaveProperty("size", 16384);
+        assert.strictEqual(entries["buffer.txt"].mode, 420);
+        assert.strictEqual(entries["buffer.txt"].crc32, 3893830384);
+        assert.strictEqual(entries["buffer.txt"].size, 16384);
       });
 
       it("should append stream", () => {
-        expect(entries).toHaveProperty(["stream.txt"]);
-        expect(entries["stream.txt"]).toHaveProperty("name", "stream.txt");
-        expect(entries["stream.txt"]).toHaveProperty("type", "file");
-        expect(entries["stream.txt"]).toHaveProperty(
-          "date",
+        assert.ok("stream.txt" in entries);
+        assert.strictEqual(entries["stream.txt"].name, "stream.txt");
+        assert.strictEqual(entries["stream.txt"].type, "file");
+        assert.strictEqual(
+          entries["stream.txt"].date,
           "2013-01-03T14:26:38.000Z",
         );
-        expect(entries["stream.txt"]).toHaveProperty("mode", 420);
-        expect(entries["stream.txt"]).toHaveProperty("crc32", 585446183);
-        expect(entries["stream.txt"]).toHaveProperty("size", 19);
+        assert.strictEqual(entries["stream.txt"].mode, 420);
+        assert.strictEqual(entries["stream.txt"].crc32, 585446183);
+        assert.strictEqual(entries["stream.txt"].size, 19);
       });
 
       it("should append stream-like source", () => {
-        expect(entries).toHaveProperty(["stream-like.txt"]);
-        expect(entries["stream-like.txt"]).toHaveProperty(
-          "name",
-          "stream-like.txt",
-        );
-        expect(entries["stream-like.txt"]).toHaveProperty("type", "file");
-        expect(entries["stream-like.txt"]).toHaveProperty(
-          "date",
+        assert.ok("stream-like.txt" in entries);
+        assert.strictEqual(entries["stream-like.txt"].name, "stream-like.txt");
+        assert.strictEqual(entries["stream-like.txt"].type, "file");
+        assert.strictEqual(
+          entries["stream-like.txt"].date,
           "2013-01-03T14:26:38.000Z",
         );
-        expect(entries["stream-like.txt"]).toHaveProperty("mode", 420);
-        expect(entries["stream-like.txt"]).toHaveProperty("crc32", 3632233996);
-        expect(entries["stream-like.txt"]).toHaveProperty("size", 4);
+        assert.strictEqual(entries["stream-like.txt"].mode, 420);
+        assert.strictEqual(entries["stream-like.txt"].crc32, 3632233996);
+        assert.strictEqual(entries["stream-like.txt"].size, 4);
       });
 
       it("should append directory", () => {
-        expect(entries).toHaveProperty("directory/");
-        expect(entries["directory/"]).toHaveProperty("name", "directory/");
-        expect(entries["directory/"]).toHaveProperty("type", "directory");
-        expect(entries["directory/"]).toHaveProperty(
-          "date",
+        assert.ok("directory/" in entries);
+        assert.strictEqual(entries["directory/"].name, "directory/");
+        assert.strictEqual(entries["directory/"].type, "directory");
+        assert.strictEqual(
+          entries["directory/"].date,
           "2013-01-03T14:26:38.000Z",
         );
-        expect(entries["directory/"]).toHaveProperty("mode", 493);
-        expect(entries["directory/"]).toHaveProperty("crc32", 0);
-        expect(entries["directory/"]).toHaveProperty("size", 0);
+        assert.strictEqual(entries["directory/"].mode, 493);
+        assert.strictEqual(entries["directory/"].crc32, 0);
+        assert.strictEqual(entries["directory/"].size, 0);
       });
     });
 
     describe("#directory", () => {
       let actual;
-      let archive;
+      let archive: JsonArchive;
       const entries = {};
 
-      beforeAll((done) => {
+      before(async () => {
         archive = new JsonArchive();
-        const testStream = createWriteStream("tmp/directory.json");
-        testStream.on("close", () => {
-          actual = readJSON("tmp/directory.json");
-          actual.forEach((entry) => {
-            entries[entry.name] = entry;
+        await new Promise<void>((resolve) => {
+          const testStream = createWriteStream("tmp/directory.json");
+          testStream.on("close", () => {
+            actual = readJSON("tmp/directory.json");
+            actual.forEach((entry) => {
+              entries[entry.name] = entry;
+            });
+            resolve();
           });
-          done();
+          archive.pipe(testStream);
+          archive
+            .directory("tests/fixtures/directory", null, { date: testDate })
+            .directory("tests/fixtures/directory", "Win\\DS\\", {
+              date: testDate,
+            })
+            .directory(
+              "tests/fixtures/directory",
+              "directory",
+              function (data) {
+                if (data.name === "ignore.txt") {
+                  return false;
+                }
+                data.funcProp = true;
+                return data;
+              },
+            )
+            .finalize();
         });
-        archive.pipe(testStream);
-        archive
-          .directory("tests/fixtures/directory", null, { date: testDate })
-          .directory("tests/fixtures/directory", "Win\\DS\\", {
-            date: testDate,
-          })
-          .directory("tests/fixtures/directory", "directory", function (data) {
-            if (data.name === "ignore.txt") {
-              return false;
-            }
-            data.funcProp = true;
-            return data;
-          })
-          .finalize();
       });
 
       it("should append multiple entries", () => {
-        expect(Array.isArray(actual)).toBe(true);
-        expect(entries).toHaveProperty(["tests/fixtures/directory/level0.txt"]);
-        expect(entries).toHaveProperty("tests/fixtures/directory/subdir/");
-        expect(entries).toHaveProperty([
-          "tests/fixtures/directory/subdir/level1.txt",
-        ]);
-        expect(entries).toHaveProperty(
-          "tests/fixtures/directory/subdir/subsub/",
+        assert.ok(Array.isArray(actual));
+        assert.ok("tests/fixtures/directory/level0.txt" in entries);
+        assert.ok("tests/fixtures/directory/subdir/" in entries);
+        assert.ok("tests/fixtures/directory/subdir/level1.txt" in entries);
+        assert.ok("tests/fixtures/directory/subdir/subsub/" in entries);
+        assert.ok(
+          "tests/fixtures/directory/subdir/subsub/level2.txt" in entries,
         );
-        expect(entries).toHaveProperty([
-          "tests/fixtures/directory/subdir/subsub/level2.txt",
-        ]);
-        expect(entries["tests/fixtures/directory/level0.txt"]).toHaveProperty(
-          "date",
+        assert.strictEqual(
+          entries["tests/fixtures/directory/level0.txt"].date,
           "2013-01-03T14:26:38.000Z",
         );
-        expect(entries["tests/fixtures/directory/subdir/"]).toHaveProperty(
-          "date",
+        assert.strictEqual(
+          entries["tests/fixtures/directory/subdir/"].date,
           "2013-01-03T14:26:38.000Z",
         );
-        expect(entries).toHaveProperty(["directory/level0.txt"]);
-        expect(entries).toHaveProperty("directory/subdir/");
-        expect(entries).toHaveProperty(["directory/subdir/level1.txt"]);
-        expect(entries).toHaveProperty("directory/subdir/subsub/");
-        expect(entries).toHaveProperty(["directory/subdir/subsub/level2.txt"]);
+        assert.ok("directory/level0.txt" in entries);
+        assert.ok("directory/subdir/" in entries);
+        assert.ok("directory/subdir/level1.txt" in entries);
+        assert.ok("directory/subdir/subsub/" in entries);
+        assert.ok("directory/subdir/subsub/level2.txt" in entries);
       });
 
       it("should support setting data properties via function", () => {
-        expect(entries).toHaveProperty(["directory/level0.txt"]);
-        expect(entries["directory/level0.txt"]).toHaveProperty(
-          "funcProp",
-          true,
-        );
+        assert.ok("directory/level0.txt" in entries);
+        assert.strictEqual(entries["directory/level0.txt"].funcProp, true);
       });
 
       it("should support ignoring matches via function", () => {
-        expect(entries).not.toHaveProperty(["directory/ignore.txt"]);
+        assert.ok(!("directory/ignore.txt" in entries));
       });
 
       it("should find dot files", () => {
-        expect(entries).toHaveProperty(["directory/.dotfile"]);
+        assert.ok("directory/.dotfile" in entries);
       });
 
       it("should retain symlinks", () => {
-        expect(entries).toHaveProperty([
-          "tests/fixtures/directory/subdir/level0link.txt",
-        ]);
-        expect(entries).toHaveProperty(["directory/subdir/level0link.txt"]);
+        assert.ok("tests/fixtures/directory/subdir/level0link.txt" in entries);
+        assert.ok("directory/subdir/level0link.txt" in entries);
       });
 
       it("should retain directory symlink", () => {
-        expect(entries).toHaveProperty(
-          "tests/fixtures/directory/subdir/subsublink",
-        );
-        expect(entries).toHaveProperty("directory/subdir/subsublink");
+        assert.ok("tests/fixtures/directory/subdir/subsublink" in entries);
+        assert.ok("directory/subdir/subsublink" in entries);
       });
 
       it("should handle windows path separators in prefix", () => {
-        expect(entries).toHaveProperty(["Win/DS/level0.txt"]);
+        assert.ok("Win/DS/level0.txt" in entries);
       });
     });
 
@@ -292,62 +289,61 @@ describe("archiver", () => {
       let archive;
       const entries = {};
 
-      beforeAll((done) => {
+      before(async () => {
         archive = new JsonArchive();
-        const testStream = createWriteStream("tmp/file.json");
-        testStream.on("close", () => {
-          actual = readJSON("tmp/file.json");
-          actual.forEach((entry) => {
-            entries[entry.name] = entry;
+        await new Promise<void>((resolve) => {
+          const testStream = createWriteStream("tmp/file.json");
+          testStream.on("close", () => {
+            actual = readJSON("tmp/file.json");
+            actual.forEach((entry) => {
+              entries[entry.name] = entry;
+            });
+            resolve();
           });
-          done();
+          archive.pipe(testStream);
+          archive
+            .file("tests/fixtures/test.txt", {
+              name: "test.txt",
+              date: testDate,
+            })
+            .file("tests/fixtures/test.txt")
+            .file("tests/fixtures/executable.sh", { mode: win32 ? 511 : null }) // 0777
+            .finalize();
         });
-        archive.pipe(testStream);
-        archive
-          .file("tests/fixtures/test.txt", { name: "test.txt", date: testDate })
-          .file("tests/fixtures/test.txt")
-          .file("tests/fixtures/executable.sh", { mode: win32 ? 511 : null }) // 0777
-          .finalize();
       });
 
       it("should append multiple entries", () => {
-        expect(Array.isArray(actual)).toBe(true);
-        expect(actual).toHaveLength(3);
+        assert.ok(Array.isArray(actual));
+        assert.strictEqual(actual.length, 3);
       });
 
       it("should append filepath", () => {
-        expect(entries).toHaveProperty(["test.txt"]);
-        expect(entries["test.txt"]).toHaveProperty("name", "test.txt");
-        expect(entries["test.txt"]).toHaveProperty(
-          "date",
+        assert.ok("test.txt" in entries);
+        assert.strictEqual(entries["test.txt"].name, "test.txt");
+        assert.strictEqual(
+          entries["test.txt"].date,
           "2013-01-03T14:26:38.000Z",
         );
-        expect(entries["test.txt"]).toHaveProperty("crc32", 585446183);
-        expect(entries["test.txt"]).toHaveProperty("size", 19);
+        assert.strictEqual(entries["test.txt"].crc32, 585446183);
+        assert.strictEqual(entries["test.txt"].size, 19);
       });
 
       it("should fallback to filepath when no name is set", () => {
-        expect(entries).toHaveProperty(["tests/fixtures/test.txt"]);
+        assert.ok("tests/fixtures/test.txt" in entries);
       });
 
       it("should fallback to file stats when applicable", () => {
-        expect(entries).toHaveProperty(["tests/fixtures/executable.sh"]);
-        expect(entries["tests/fixtures/executable.sh"]).toHaveProperty(
-          "name",
+        assert.ok("tests/fixtures/executable.sh" in entries);
+        assert.strictEqual(
+          entries["tests/fixtures/executable.sh"].name,
           "tests/fixtures/executable.sh",
         );
-        expect(entries["tests/fixtures/executable.sh"]).toHaveProperty(
-          "mode",
-          511,
-        );
-        expect(entries["tests/fixtures/executable.sh"]).toHaveProperty(
-          "crc32",
+        assert.strictEqual(entries["tests/fixtures/executable.sh"].mode, 511);
+        assert.strictEqual(
+          entries["tests/fixtures/executable.sh"].crc32,
           3957348457,
         );
-        expect(entries["tests/fixtures/executable.sh"]).toHaveProperty(
-          "size",
-          11,
-        );
+        assert.strictEqual(entries["tests/fixtures/executable.sh"].size, 11);
       });
     });
 
@@ -356,42 +352,44 @@ describe("archiver", () => {
       let archive;
       const entries = {};
 
-      beforeAll((done) => {
+      before(async () => {
         archive = new JsonArchive();
-        const testStream = createWriteStream("tmp/glob.json");
-        testStream.on("close", () => {
-          actual = readJSON("tmp/glob.json");
-          actual.forEach((entry) => {
-            entries[entry.name] = entry;
+        await new Promise<void>((resolve) => {
+          const testStream = createWriteStream("tmp/glob.json");
+          testStream.on("close", () => {
+            actual = readJSON("tmp/glob.json");
+            actual.forEach((entry) => {
+              entries[entry.name] = entry;
+            });
+            resolve();
           });
-          done();
+          archive.pipe(testStream);
+          archive
+            .glob("tests/fixtures/test.txt", null)
+            .glob("tests/fixtures/empty.txt", null)
+            .glob("tests/fixtures/executable.sh", null)
+            .glob("tests/fixtures/directory/**/*", {
+              ignore: "tests/fixtures/directory/subdir/**/*",
+              nodir: true,
+            })
+            .glob("**/*", { cwd: "tests/fixtures/directory/subdir/" })
+            .finalize();
         });
-        archive.pipe(testStream);
-        archive
-          .glob("tests/fixtures/test.txt", null)
-          .glob("tests/fixtures/empty.txt", null)
-          .glob("tests/fixtures/executable.sh", null)
-          .glob("tests/fixtures/directory/**/*", {
-            ignore: "tests/fixtures/directory/subdir/**/*",
-            nodir: true,
-          })
-          .glob("**/*", { cwd: "tests/fixtures/directory/subdir/" })
-          .finalize();
       });
 
       it("should append multiple entries", () => {
-        expect(Array.isArray(actual)).toBe(true);
-        expect(entries).toHaveProperty(["tests/fixtures/test.txt"]);
-        expect(entries).toHaveProperty(["tests/fixtures/executable.sh"]);
-        expect(entries).toHaveProperty(["tests/fixtures/empty.txt"]);
-        expect(entries).toHaveProperty(["tests/fixtures/directory/level0.txt"]);
-        expect(entries).toHaveProperty(["level1.txt"]);
-        expect(entries).toHaveProperty(["subsub/level2.txt"]);
+        assert.ok(Array.isArray(actual));
+        assert.ok("tests/fixtures/test.txt" in entries);
+        assert.ok("tests/fixtures/executable.sh" in entries);
+        assert.ok("tests/fixtures/empty.txt" in entries);
+        assert.ok("tests/fixtures/directory/level0.txt" in entries);
+        assert.ok("level1.txt" in entries);
+        assert.ok("subsub/level2.txt" in entries);
       });
     });
 
     describe("#promise", () => {
-      it("should use a promise", (done) => {
+      it("should use a promise", async () => {
         const archive = new JsonArchive();
         const testStream = createWriteStream("tmp/promise.json");
         archive.pipe(testStream);
@@ -401,41 +399,42 @@ describe("archiver", () => {
             name: "stream.txt",
             date: testDate,
           })
-          .append(null, { name: "directory/", date: testDate })
-          .finalize()
-          .then(() => {
-            done();
-          });
+          .append(null, { name: "directory/", date: testDate });
+        await archive.finalize();
       });
     });
 
     describe("#errors", () => {
-      it("should allow continue on stat failing", (done) => {
+      it("should allow continue on stat failing", async () => {
         const archive = new JsonArchive();
-        const testStream = createWriteStream("tmp/errors-stat.json");
-        testStream.on("close", () => {
-          done();
+        await new Promise<void>((resolve) => {
+          const testStream = createWriteStream("tmp/errors-stat.json");
+          testStream.on("close", () => {
+            resolve();
+          });
+          archive.pipe(testStream);
+          archive
+            .file("tests/fixtures/test.txt")
+            .file("tests/fixtures/test-missing.txt")
+            .file("tests/fixtures/empty.txt")
+            .finalize();
         });
-        archive.pipe(testStream);
-        archive
-          .file("tests/fixtures/test.txt")
-          .file("tests/fixtures/test-missing.txt")
-          .file("tests/fixtures/empty.txt")
-          .finalize();
       });
 
-      it("should allow continue on with several stat failings", (done) => {
+      it("should allow continue on with several stat failings", async () => {
         const archive = new JsonArchive();
-        const testStream = createWriteStream("tmp/errors-stat.json");
-        testStream.on("close", () => {
-          done();
+        await new Promise<void>((resolve) => {
+          const testStream = createWriteStream("tmp/errors-stat.json");
+          testStream.on("close", () => {
+            resolve();
+          });
+          archive.pipe(testStream);
+          archive.file("tests/fixtures/test.txt");
+          for (let i = 1; i <= 20; i++) {
+            archive.file("tests/fixtures/test-missing.txt");
+          }
+          archive.finalize();
         });
-        archive.pipe(testStream);
-        archive.file("tests/fixtures/test.txt");
-        for (let i = 1; i <= 20; i++) {
-          archive.file("tests/fixtures/test-missing.txt");
-        }
-        archive.finalize();
       });
     });
   });
@@ -445,38 +444,39 @@ describe("archiver", () => {
     let archive: JsonArchive;
     const entries = {};
 
-    beforeAll((done) => {
+    before(async () => {
       archive = new JsonArchive();
-      const testStream = createWriteStream("tmp/symlink.json");
-      testStream.on("close", () => {
-        actual = readJSON("tmp/symlink.json");
-        actual.forEach((entry) => {
-          entries[entry.name] = entry;
+      await new Promise<void>((resolve) => {
+        const testStream = createWriteStream("tmp/symlink.json");
+        testStream.on("close", () => {
+          actual = readJSON("tmp/symlink.json");
+          actual.forEach((entry) => {
+            entries[entry.name] = entry;
+          });
+          resolve();
         });
-        done();
+        archive.pipe(testStream);
+        archive
+          .append("file-a", { name: "file-a" })
+          .symlink("directory-a/symlink-to-file-a", "../file-a")
+          .symlink(
+            "directory-b/directory-c/symlink-to-directory-a",
+            "../../directory-a",
+            493,
+          )
+          .finalize();
       });
-      archive.pipe(testStream);
-      archive
-        .append("file-a", { name: "file-a" })
-        .symlink("directory-a/symlink-to-file-a", "../file-a")
-        .symlink(
-          "directory-b/directory-c/symlink-to-directory-a",
-          "../../directory-a",
-          493,
-        )
-        .finalize();
     });
 
     it("should append multiple entries", () => {
-      expect(Array.isArray(actual)).toBe(true);
-      expect(entries).toHaveProperty("file-a");
-      expect(entries).toHaveProperty("directory-a/symlink-to-file-a");
-      expect(entries).toHaveProperty(
-        "directory-b/directory-c/symlink-to-directory-a",
+      assert.ok(Array.isArray(actual));
+      assert.ok("file-a" in entries);
+      assert.ok("directory-a/symlink-to-file-a" in entries);
+      assert.ok("directory-b/directory-c/symlink-to-directory-a" in entries);
+      assert.strictEqual(
+        entries["directory-b/directory-c/symlink-to-directory-a"].mode,
+        493,
       );
-      expect(
-        entries["directory-b/directory-c/symlink-to-directory-a"],
-      ).toHaveProperty("mode", 493);
     });
   });
 });

--- a/packages/archiver/tests/plugins.test.ts
+++ b/packages/archiver/tests/plugins.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import assert from "node:assert/strict";
 import {
   chmodSync,
   createReadStream,
@@ -8,6 +8,7 @@ import {
   createWriteStream,
   mkdirSync,
 } from "node:fs";
+import { describe, it, before, after } from "node:test";
 
 import * as tar from "tar";
 import yauzl from "yauzl";
@@ -20,7 +21,7 @@ const testDate = new Date("Jan 03 2013 14:26:38 GMT");
 const win32 = process.platform === "win32";
 
 describe("plugins", () => {
-  beforeAll(() => {
+  before(() => {
     mkdirSync("tmp", { recursive: true });
     if (!win32) {
       chmodSync("tests/fixtures/executable.sh", 511); // 0777
@@ -39,7 +40,7 @@ describe("plugins", () => {
     }
   });
 
-  afterAll(() => {
+  after(() => {
     unlinkSync("tests/fixtures/directory/subdir/level0link.txt");
     unlinkSync("tests/fixtures/directory/subdir/subsublink");
   });
@@ -49,109 +50,111 @@ describe("plugins", () => {
     let archive: TarArchive;
     const entries = {};
 
-    beforeAll((done) => {
+    before(async () => {
       archive = new TarArchive();
-      const testStream = new tar.Parser();
+      await new Promise<void>((resolve) => {
+        const testStream = new tar.Parser();
 
-      testStream.on("entry", (entry) => {
-        actual.push(entry.path);
-        entries[entry.path] = {
-          type: entry.type,
-          path: entry.path,
-          mode: entry.mode,
-          uid: entry.uid,
-          gid: entry.gid,
-          uname: entry.uname,
-          gname: entry.gname,
-          size: entry.size,
-          mtime: entry.mtime,
-          atime: entry.atime,
-          ctime: entry.ctime,
-          linkpath: entry.linkpath,
-        };
-        entry.resume();
+        testStream.on("entry", (entry) => {
+          actual.push(entry.path);
+          entries[entry.path] = {
+            type: entry.type,
+            path: entry.path,
+            mode: entry.mode,
+            uid: entry.uid,
+            gid: entry.gid,
+            uname: entry.uname,
+            gname: entry.gname,
+            size: entry.size,
+            mtime: entry.mtime,
+            atime: entry.atime,
+            ctime: entry.ctime,
+            linkpath: entry.linkpath,
+          };
+          entry.resume();
+        });
+
+        testStream.on("end", () => {
+          resolve();
+        });
+
+        archive.pipe(testStream);
+        archive
+          .append(testBuffer, { name: "buffer.txt", date: testDate })
+          .append(createReadStream("tests/fixtures/test.txt"), {
+            name: "stream.txt",
+            date: testDate,
+          })
+          .append(null, { name: "folder/", date: testDate })
+          .directory("tests/fixtures/directory", "directory")
+          .symlink("manual-link.txt", "manual-link-target.txt")
+          .finalize();
       });
-
-      testStream.on("end", () => {
-        done();
-      });
-
-      archive.pipe(testStream);
-      archive
-        .append(testBuffer, { name: "buffer.txt", date: testDate })
-        .append(createReadStream("tests/fixtures/test.txt"), {
-          name: "stream.txt",
-          date: testDate,
-        })
-        .append(null, { name: "folder/", date: testDate })
-        .directory("tests/fixtures/directory", "directory")
-        .symlink("manual-link.txt", "manual-link-target.txt")
-        .finalize();
     });
 
     it("should append multiple entries", () => {
-      expect(Array.isArray(actual)).toBe(true);
-      expect(actual.length).toBeGreaterThan(10);
+      assert.ok(Array.isArray(actual));
+      assert.ok(actual.length > 10);
     });
 
     it("should append buffer", () => {
-      expect(entries).toHaveProperty(["buffer.txt"]);
-      expect(entries["buffer.txt"]).toHaveProperty("path", "buffer.txt");
-      expect(entries["buffer.txt"]).toHaveProperty("type", "File");
-      expect(entries["buffer.txt"]).toHaveProperty("mode", 420);
-      expect(entries["buffer.txt"]).toHaveProperty("size", 16384);
+      assert.ok("buffer.txt" in entries);
+      assert.strictEqual(entries["buffer.txt"].path, "buffer.txt");
+      assert.strictEqual(entries["buffer.txt"].type, "File");
+      assert.strictEqual(entries["buffer.txt"].mode, 420);
+      assert.strictEqual(entries["buffer.txt"].size, 16384);
     });
 
     it("should append stream", () => {
-      expect(entries).toHaveProperty(["stream.txt"]);
-      expect(entries["stream.txt"]).toHaveProperty("path", "stream.txt");
-      expect(entries["stream.txt"]).toHaveProperty("type", "File");
-      expect(entries["stream.txt"]).toHaveProperty("mode", 420);
-      expect(entries["stream.txt"]).toHaveProperty("size", 19);
+      assert.ok("stream.txt" in entries);
+      assert.strictEqual(entries["stream.txt"].path, "stream.txt");
+      assert.strictEqual(entries["stream.txt"].type, "File");
+      assert.strictEqual(entries["stream.txt"].mode, 420);
+      assert.strictEqual(entries["stream.txt"].size, 19);
     });
 
     it("should append folder", () => {
-      expect(entries).toHaveProperty("folder/");
-      expect(entries["folder/"]).toHaveProperty("path", "folder/");
-      expect(entries["folder/"]).toHaveProperty("type", "Directory");
-      expect(entries["folder/"]).toHaveProperty("mode", 493);
-      expect(entries["folder/"]).toHaveProperty("size", 0);
+      assert.ok("folder/" in entries);
+      assert.strictEqual(entries["folder/"].path, "folder/");
+      assert.strictEqual(entries["folder/"].type, "Directory");
+      assert.strictEqual(entries["folder/"].mode, 493);
+      assert.strictEqual(entries["folder/"].size, 0);
     });
 
     it("should append manual symlink", () => {
-      expect(entries).toHaveProperty(["manual-link.txt"]);
-      expect(entries["manual-link.txt"]).toHaveProperty("type", "SymbolicLink");
-      expect(entries["manual-link.txt"]).toHaveProperty(
-        "linkpath",
+      assert.ok("manual-link.txt" in entries);
+      assert.strictEqual(entries["manual-link.txt"].type, "SymbolicLink");
+      assert.strictEqual(
+        entries["manual-link.txt"].linkpath,
         "manual-link-target.txt",
       );
     });
 
     it("should append via directory", () => {
-      expect(entries).toHaveProperty(["directory/subdir/level1.txt"]);
-      expect(entries).toHaveProperty(["directory/subdir/level0link.txt"]);
+      assert.ok("directory/subdir/level1.txt" in entries);
+      assert.ok("directory/subdir/level0link.txt" in entries);
     });
 
     it("should retain symlinks via directory", () => {
       if (win32) {
         return;
       }
-      expect(entries).toHaveProperty(["directory/subdir/level0link.txt"]);
-      expect(entries["directory/subdir/level0link.txt"]).toHaveProperty(
-        "type",
+      assert.ok("directory/subdir/level0link.txt" in entries);
+      assert.strictEqual(
+        entries["directory/subdir/level0link.txt"].type,
         "SymbolicLink",
       );
-      expect(entries["directory/subdir/level0link.txt"]).toHaveProperty(
-        "linkpath",
+      assert.strictEqual(
+        entries["directory/subdir/level0link.txt"].linkpath,
         "../level0.txt",
       );
-      expect(entries).toHaveProperty("directory/subdir/subsublink");
-      expect(entries["directory/subdir/subsublink"]).toHaveProperty(
-        "type",
+      assert.ok("directory/subdir/subsublink" in entries);
+      assert.strictEqual(
+        entries["directory/subdir/subsublink"].type,
         "SymbolicLink",
       );
-      expect(entries["directory/subdir/subsublink"]).toHaveProperty(
-        "linkpath",
+      assert.strictEqual(
+        entries["directory/subdir/subsublink"].linkpath,
         "subsub",
       );
     });
@@ -163,118 +166,119 @@ describe("plugins", () => {
     const entries = {};
     let zipComment = "";
 
-    beforeAll((done) => {
+    before(async () => {
       archive = new ZipArchive({ comment: "archive comment" });
-      const testStream = createWriteStream("tmp/plugin.zip");
+      await new Promise<void>((resolve) => {
+        const testStream = createWriteStream("tmp/plugin.zip");
 
-      testStream.on("close", () => {
-        yauzl.open("tmp/plugin.zip", (err, zip) => {
-          if (err) throw err;
-          zip.on("entry", (entry) => {
-            actual.push(entry.fileName);
-            entries[entry.fileName] = entry;
-          });
-          zip.on("close", () => {
-            zipComment = zip.comment || "";
-            done();
+        testStream.on("close", () => {
+          yauzl.open("tmp/plugin.zip", (err, zip) => {
+            if (err) throw err;
+            zip.on("entry", (entry) => {
+              actual.push(entry.fileName);
+              entries[entry.fileName] = entry;
+            });
+            zip.on("close", () => {
+              zipComment = zip.comment || "";
+              resolve();
+            });
           });
         });
-      });
 
-      archive.pipe(testStream);
-      archive
-        .append(testBuffer, {
-          name: "buffer.txt",
-          date: testDate,
-          comment: "entry comment",
-        })
-        .append(createReadStream("tests/fixtures/test.txt"), {
-          name: "stream.txt",
-          date: testDate,
-        })
-        .file("tests/fixtures/executable.sh", {
-          name: "executable.sh",
-          mode: win32 ? 511 : null, // 0777
-        })
-        .directory("tests/fixtures/directory", "directory")
-        .symlink("manual-link.txt", "manual-link-target.txt")
-        .finalize();
+        archive.pipe(testStream);
+        archive
+          .append(testBuffer, {
+            name: "buffer.txt",
+            date: testDate,
+            comment: "entry comment",
+          })
+          .append(createReadStream("tests/fixtures/test.txt"), {
+            name: "stream.txt",
+            date: testDate,
+          })
+          .file("tests/fixtures/executable.sh", {
+            name: "executable.sh",
+            mode: win32 ? 511 : null, // 0777
+          })
+          .directory("tests/fixtures/directory", "directory")
+          .symlink("manual-link.txt", "manual-link-target.txt")
+          .finalize();
+      });
     });
 
     it("should append multiple entries", () => {
-      expect(Array.isArray(actual)).toBe(true);
-      expect(actual.length).toBeGreaterThan(10);
+      assert.ok(Array.isArray(actual));
+      assert.ok(actual.length > 10);
     });
 
     it("should append buffer", () => {
-      expect(entries).toHaveProperty(["buffer.txt"]);
-      expect(entries["buffer.txt"]).toHaveProperty("uncompressedSize", 16384);
-      expect(entries["buffer.txt"]).toHaveProperty("crc32", 3893830384);
+      assert.ok("buffer.txt" in entries);
+      assert.strictEqual(entries["buffer.txt"].uncompressedSize, 16384);
+      assert.strictEqual(entries["buffer.txt"].crc32, 3893830384);
     });
 
     it("should append stream", () => {
-      expect(entries).toHaveProperty(["stream.txt"]);
-      expect(entries["stream.txt"]).toHaveProperty("uncompressedSize", 19);
-      expect(entries["stream.txt"]).toHaveProperty("crc32", 585446183);
+      assert.ok("stream.txt" in entries);
+      assert.strictEqual(entries["stream.txt"].uncompressedSize, 19);
+      assert.strictEqual(entries["stream.txt"].crc32, 585446183);
     });
 
     it("should append via file", () => {
-      expect(entries).toHaveProperty(["executable.sh"]);
-      expect(entries["executable.sh"]).toHaveProperty("uncompressedSize", 11);
-      expect(entries["executable.sh"]).toHaveProperty("crc32", 3957348457);
+      assert.ok("executable.sh" in entries);
+      assert.strictEqual(entries["executable.sh"].uncompressedSize, 11);
+      assert.strictEqual(entries["executable.sh"].crc32, 3957348457);
     });
 
     it("should append via directory", () => {
-      expect(entries).toHaveProperty(["directory/subdir/level1.txt"]);
-      expect(entries["directory/subdir/level1.txt"]).toHaveProperty(
-        "uncompressedSize",
+      assert.ok("directory/subdir/level1.txt" in entries);
+      assert.strictEqual(
+        entries["directory/subdir/level1.txt"].uncompressedSize,
         6,
       );
-      expect(entries["directory/subdir/level1.txt"]).toHaveProperty(
-        "crc32",
+      assert.strictEqual(
+        entries["directory/subdir/level1.txt"].crc32,
         133711013,
       );
     });
 
     it("should append manual symlink", () => {
-      expect(entries).toHaveProperty(["manual-link.txt"]);
-      expect(entries["manual-link.txt"]).toHaveProperty("crc32", 1121667014);
-      expect(entries["manual-link.txt"]).toHaveProperty(
-        "externalFileAttributes",
+      assert.ok("manual-link.txt" in entries);
+      assert.strictEqual(entries["manual-link.txt"].crc32, 1121667014);
+      assert.strictEqual(
+        entries["manual-link.txt"].externalFileAttributes,
         2684354592,
       );
     });
 
     it("should allow for custom unix mode", () => {
-      expect(entries).toHaveProperty(["executable.sh"]);
-      expect(entries["executable.sh"]).toHaveProperty(
-        "externalFileAttributes",
+      assert.ok("executable.sh" in entries);
+      assert.strictEqual(
+        entries["executable.sh"].externalFileAttributes,
         2180972576,
       );
-      expect(
+      assert.strictEqual(
         (entries["executable.sh"].externalFileAttributes >>> 16) & 0xfff,
-      ).toBe(511);
+        511,
+      );
 
-      expect(entries).toHaveProperty("directory/subdir/");
-      expect(entries["directory/subdir/"]).toHaveProperty(
-        "externalFileAttributes",
+      assert.ok("directory/subdir/" in entries);
+      assert.strictEqual(
+        entries["directory/subdir/"].externalFileAttributes,
         1106051088,
       );
-      expect(
+      assert.strictEqual(
         (entries["directory/subdir/"].externalFileAttributes >>> 16) & 0xfff,
-      ).toBe(493);
+        493,
+      );
     });
 
     it("should allow for entry comments", () => {
-      expect(entries).toHaveProperty(["buffer.txt"]);
-      expect(entries["buffer.txt"]).toHaveProperty(
-        "fileComment",
-        "entry comment",
-      );
+      assert.ok("buffer.txt" in entries);
+      assert.strictEqual(entries["buffer.txt"].fileComment, "entry comment");
     });
 
     it("should allow for archive comment", () => {
-      expect(zipComment).toBe("archive comment");
+      assert.strictEqual(zipComment, "archive comment");
     });
   });
 });

--- a/packages/readdir-glob/src/index.ts
+++ b/packages/readdir-glob/src/index.ts
@@ -302,7 +302,11 @@ export class ReaddirGlob extends EventEmitter<{
 
   private iterator: ReturnType<typeof explore>;
 
-  constructor(cwd?: string, options?: Options | Callback, cb?: Callback) {
+  constructor(
+    cwd?: string | false,
+    options?: Options | Callback,
+    cb?: Callback,
+  ) {
     super();
     if (typeof options === "function") {
       cb = options;
@@ -441,7 +445,7 @@ export class ReaddirGlob extends EventEmitter<{
 }
 
 export const readdirGlob = (
-  cwd?: string,
+  cwd?: string | false,
   options?: Options | Callback,
   cb?: Callback,
 ): ReaddirGlob => new ReaddirGlob(cwd, options, cb);

--- a/packages/readdir-glob/tests/abort.test.ts
+++ b/packages/readdir-glob/tests/abort.test.ts
@@ -1,9 +1,9 @@
-import { spyOn, it, beforeEach, describe } from "bun:test";
 import * as fs from "node:fs";
+import { describe, it, beforeEach, mock } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
-describe.todo("abort", () => {
+describe.skip("abort", () => {
   beforeEach(() => {
     process.chdir(__dirname);
   });
@@ -15,21 +15,21 @@ describe.todo("abort", () => {
       glob(".", { pattern: "a/" }),
     ];
 
-    globs.forEach((glob) =>
-      spyOn(glob, "emit").mockImplementation(() => {
+    globs.forEach((g) =>
+      mock.method(g, "emit", () => {
         throw new Error("Invalid call");
       }),
     );
-    spyOn(fs, "readdir").mockImplementation(() => {
+    mock.method(fs, "readdir", () => {
       throw new Error("Invalid call");
     });
-    spyOn(fs, "stat").mockImplementation(() => {
+    mock.method(fs, "stat", () => {
       throw new Error("Invalid call");
     });
-    spyOn(fs, "lstat").mockImplementation(() => {
+    mock.method(fs, "lstat", () => {
       throw new Error("Invalid call");
     });
 
-    globs.forEach((glob) => glob.abort());
+    globs.forEach((g) => g.abort());
   });
 });

--- a/packages/readdir-glob/tests/absolute.test.ts
+++ b/packages/readdir-glob/tests/absolute.test.ts
@@ -1,5 +1,6 @@
-import { it, beforeEach, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
 import { isAbsolute } from "node:path";
+import { describe, it, beforeEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -11,20 +12,21 @@ describe("absolute", () => {
   });
 
   [true, false].forEach(function (mark) {
-    it(`Emits absolute matches if option set, mark=${mark}`, function (done) {
-      const pattern = "a/b/**";
-      const g = glob(".", { pattern });
+    it(`Emits absolute matches if option set, mark=${mark}`, async () => {
+      await new Promise<void>((resolve) => {
+        const pattern = "a/b/**";
+        const g = glob(".", { pattern });
 
-      let matchCount = 0;
-      g.on("match", (m) => {
-        expect(isAbsolute(m.absolute)).toBeTrue();
-        matchCount++;
-        // console.log("..");
-      });
+        let matchCount = 0;
+        g.on("match", (m) => {
+          assert.ok(isAbsolute(m.absolute));
+          matchCount++;
+        });
 
-      g.on("end", () => {
-        expect(matchCount).toBe(bashResults[pattern].length);
-        done();
+        g.on("end", () => {
+          assert.strictEqual(matchCount, bashResults[pattern].length);
+          resolve();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/bash-comparison.test.ts
+++ b/packages/readdir-glob/tests/bash-comparison.test.ts
@@ -1,6 +1,7 @@
+import assert from "node:assert/strict";
 // basic test
 // show that it does the same thing by default as the shell.
-import { it, beforeEach, describe, expect } from "bun:test";
+import { describe, it, beforeEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -29,17 +30,19 @@ describe("bash-comparison", () => {
       expectedFiles = expectedFiles.filter((m) => m.indexOf("symlink") === -1);
     }
 
-    it(pattern, (done) => {
-      const g = glob(".", { pattern });
-      let matches: string[] = [];
-      g.on("match", (match) => {
-        matches.push(match.relative);
-      });
-      g.on("end", () => {
-        // sort and unmark, just to match the shell results
-        matches = cleanResults(matches);
-        expect(matches).toEqual(expectedFiles);
-        done();
+    it(pattern, async () => {
+      await new Promise<void>((resolve) => {
+        const g = glob(".", { pattern });
+        let matches: string[] = [];
+        g.on("match", (match) => {
+          matches.push(match.relative);
+        });
+        g.on("end", () => {
+          // sort and unmark, just to match the shell results
+          matches = cleanResults(matches);
+          assert.deepStrictEqual(matches, expectedFiles);
+          resolve();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/broken-symlink.test.ts
+++ b/packages/readdir-glob/tests/broken-symlink.test.ts
@@ -1,5 +1,6 @@
-import { it, beforeEach, describe, expect, afterEach } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { describe, it, beforeEach, afterEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -12,7 +13,7 @@ function cleanup() {
 describe("broken-symlink", () => {
   beforeEach(() => {
     process.chdir(__dirname);
-    fs.mkdirSync(process.cwd() + "/broken-symlink/a/broken-link", {
+    fs.mkdirSync(`${process.cwd()}/broken-symlink/a/broken-link`, {
       recursive: true,
     });
     fs.symlinkSync("this-does-not-exist", "broken-symlink/a/broken-link/link");
@@ -42,18 +43,21 @@ describe("broken-symlink", () => {
     { follow: true },
   ];
 
+  const _it = win32 ? it.skip : it;
+
   patterns.forEach((pattern) => {
     opts.forEach((opt) => {
-      it.skipIf(win32)(
-        "async test pattern=" + pattern + ", opts=" + JSON.stringify(opt),
-        (done) => {
-          glob(".", { ...opt, pattern }, (er, res) => {
-            if (er) {
-              expect().fail(er.message);
-              return done();
-            }
-            expect(res.indexOf(link)).not.toBe(-1);
-            done();
+      _it(
+        `async test pattern=${pattern}, opts=${JSON.stringify(opt)}`,
+        async () => {
+          await new Promise<void>((resolve) => {
+            glob(".", { ...opt, pattern }, (er, res) => {
+              if (er) {
+                assert.fail(er.message);
+              }
+              assert.notStrictEqual(res.indexOf(link), -1);
+              resolve();
+            });
           });
         },
       );

--- a/packages/readdir-glob/tests/cwd-test.test.ts
+++ b/packages/readdir-glob/tests/cwd-test.test.ts
@@ -1,5 +1,6 @@
-import { it, beforeEach, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
 import * as path from "node:path";
+import { describe, it, beforeEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -8,55 +9,67 @@ describe("cwd-test", () => {
     process.chdir(`${__dirname}/fixtures`);
   });
 
-  it('changing cwd and searching for **/d, "."', (done) => {
-    glob(".", { pattern: "**/d" }, (er, matches) => {
-      expect(er).toBeFalsy();
-      expect(matches?.toSorted()).toEqual(["a/b/c/d", "a/c/d"]);
-      done();
+  it('changing cwd and searching for **/d, "."', async () => {
+    await new Promise<void>((resolve) => {
+      glob(".", { pattern: "**/d" }, (er, matches) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(matches?.toSorted(), ["a/b/c/d", "a/c/d"]);
+        resolve();
+      });
     });
   });
 
-  it('changing cwd and searching for **/d, "a"', (done) => {
-    glob(path.resolve("a"), { pattern: "**/d" }, (er, matches) => {
-      expect(er).toBeFalsy();
-      expect(matches?.toSorted()).toEqual(["b/c/d", "c/d"]);
-      done();
+  it('changing cwd and searching for **/d, "a"', async () => {
+    await new Promise<void>((resolve) => {
+      glob(path.resolve("a"), { pattern: "**/d" }, (er, matches) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(matches?.toSorted(), ["b/c/d", "c/d"]);
+        resolve();
+      });
     });
   });
 
-  it('changing cwd and searching for **/d, "a/b"', (done) => {
-    glob(path.resolve("a/b"), { pattern: "**/d" }, (er, matches) => {
-      expect(er).toBeFalsy();
-      expect(matches).toEqual(["c/d"]);
-      done();
+  it('changing cwd and searching for **/d, "a/b"', async () => {
+    await new Promise<void>((resolve) => {
+      glob(path.resolve("a/b"), { pattern: "**/d" }, (er, matches) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(matches, ["c/d"]);
+        resolve();
+      });
     });
   });
 
-  it('changing cwd and searching for **/d, "a/b/"', (done) => {
-    glob(path.resolve("a/b/"), { pattern: "**/d" }, (er, matches) => {
-      expect(er).toBeFalsy();
-      expect(matches).toEqual(["c/d"]);
-      done();
+  it('changing cwd and searching for **/d, "a/b/"', async () => {
+    await new Promise<void>((resolve) => {
+      glob(path.resolve("a/b/"), { pattern: "**/d" }, (er, matches) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(matches, ["c/d"]);
+        resolve();
+      });
     });
   });
 
-  it("changing cwd and searching for **/d, process.cwd()", (done) => {
-    glob(process.cwd(), { pattern: "**/d" }, (er, matches) => {
-      expect(er).toBeFalsy();
-      expect(matches?.toSorted()).toEqual(["a/b/c/d", "a/c/d"]);
-      done();
+  it("changing cwd and searching for **/d, process.cwd()", async () => {
+    await new Promise<void>((resolve) => {
+      glob(process.cwd(), { pattern: "**/d" }, (er, matches) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(matches?.toSorted(), ["a/b/c/d", "a/c/d"]);
+        resolve();
+      });
     });
   });
 
-  it("non-dir cwd should raise error", (done) => {
-    const notdir = "a/b/c/d";
-    const abs = path.resolve(notdir);
+  it("non-dir cwd should raise error", async () => {
+    await new Promise<void>((resolve) => {
+      const notdir = "a/b/c/d";
+      const abs = path.resolve(notdir);
 
-    glob(notdir, { pattern: "*" }, (er) => {
-      expect(er).toBeTruthy();
-      expect(er.code).toEqual("ENOTDIR");
-      expect(er.path).toEqual(abs);
-      done();
+      glob(notdir, { pattern: "*" }, (er) => {
+        assert.ok(er);
+        assert.strictEqual(er.code, "ENOTDIR");
+        assert.strictEqual(er.path, abs);
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/empty-set.test.ts
+++ b/packages/readdir-glob/tests/empty-set.test.ts
@@ -1,4 +1,5 @@
-import { it, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -12,11 +13,13 @@ const patterns = [
 
 describe("empty-set", () => {
   patterns.forEach((p) => {
-    it("Empty-set: " + JSON.stringify(p), (done) => {
-      glob(".", { pattern: p }, (e, f) => {
-        expect(e).toBeNull();
-        expect(f).toEqual([]);
-        done();
+    it("Empty-set: " + JSON.stringify(p), async () => {
+      await new Promise<void>((resolve) => {
+        glob(".", { pattern: p }, (e, f) => {
+          assert.strictEqual(e, null);
+          assert.deepStrictEqual(f, []);
+          resolve();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/enotsup.test.ts
+++ b/packages/readdir-glob/tests/enotsup.test.ts
@@ -1,14 +1,15 @@
-import { it, beforeEach, describe, expect, spyOn } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { describe, it, beforeEach, mock } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
-describe.todo("enotsup", () => {
+describe.skip("enotsup", () => {
   beforeEach(() => {
     process.chdir(`${__dirname}/fixtures`);
     const readdir = fs.readdir;
-    spyOn(fs, "readdir").mockImplementation(function (p, opts, cb) {
+    mock.method(fs, "readdir", function (p, opts, cb) {
       if (
         allowedDirs.indexOf(path.resolve(p)) === -1 &&
         !p.match(/[\\/]node_modules[\\/]/)
@@ -38,13 +39,15 @@ describe.todo("enotsup", () => {
   ];
   const pattern = "a/**/h";
 
-  it(pattern, (done) => {
-    glob(".", { pattern }, (er, res) => {
-      expect(er).toBeFalsy();
-      expect(sawAsyncENOTSUP).toBeTruthy();
-      res.sort();
-      expect(res).toEqual(["a/abcdef/g/h", "a/abcfed/g/h"]);
-      done();
+  it(pattern, async () => {
+    await new Promise<void>((resolve) => {
+      glob(".", { pattern }, (er, res) => {
+        assert.ok(!er);
+        assert.ok(sawAsyncENOTSUP);
+        res.sort();
+        assert.deepStrictEqual(res, ["a/abcdef/g/h", "a/abcfed/g/h"]);
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/eperm-stat.test.ts
+++ b/packages/readdir-glob/tests/eperm-stat.test.ts
@@ -1,14 +1,15 @@
-import { it, beforeEach, describe, expect, spyOn } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { describe, it, beforeEach, mock } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
-describe.todo("eperm-stat", () => {
+describe.skip("eperm-stat", () => {
   beforeEach(() => {
     process.chdir(__dirname);
     const badPaths = /\ba[\\/]?$|\babcdef\b/;
     const lstat = fs.lstat;
-    spyOn(fs, "lstat").mockImplementation(function (path, cb) {
+    mock.method(fs, "lstat", function (path, cb) {
       // synthetically generate a non-ENOENT error
       if (badPaths.test(path)) {
         const er = new Error("synthetic");
@@ -19,62 +20,66 @@ describe.todo("eperm-stat", () => {
     });
   });
 
-  it("stat errors other than ENOENT are ok async", (done) => {
-    const expectedFiles = [
-      "a/abcdef",
-      "a/abcdef/g",
-      "a/abcdef/g/h",
-      "a/abcfed",
-      "a/abcfed/g",
-      "a/abcfed/g/h",
-    ];
-    glob("fixtures", { stat: true, pattern: "a/*abc*/**" }, (er, matches) => {
-      expect(er).toBeFalsy();
-      expect(matches).toEqual(expectedFiles);
-      done();
+  it("stat errors other than ENOENT are ok async", async () => {
+    await new Promise<void>((resolve) => {
+      const expectedFiles = [
+        "a/abcdef",
+        "a/abcdef/g",
+        "a/abcdef/g/h",
+        "a/abcfed",
+        "a/abcfed/g",
+        "a/abcfed/g/h",
+      ];
+      glob("fixtures", { stat: true, pattern: "a/*abc*/**" }, (er, matches) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(matches, expectedFiles);
+        resolve();
+      });
     });
   });
 
-  it("globstar with error in root async", (done) => {
-    let expectedFiles = [
-      "a",
-      "a/abcdef",
-      "a/abcdef/g",
-      "a/abcdef/g/h",
-      "a/abcfed",
-      "a/abcfed/g",
-      "a/abcfed/g/h",
-      "a/b",
-      "a/b/c",
-      "a/b/c/d",
-      "a/bc",
-      "a/bc/e",
-      "a/bc/e/f",
-      "a/c",
-      "a/c/d",
-      "a/c/d/c",
-      "a/c/d/c/b",
-      "a/cb",
-      "a/cb/e",
-      "a/cb/e/f",
-      "a/symlink",
-      "a/symlink/a",
-      "a/symlink/a/b",
-      "a/symlink/a/b/c",
-      "a/x",
-      "a/z",
-    ];
-    if (process.platform === "win32") {
-      expectedFiles = expectedFiles.filter(
-        (path) => path.indexOf("/symlink") === -1,
-      );
-    }
+  it("globstar with error in root async", async () => {
+    await new Promise<void>((resolve) => {
+      let expectedFiles = [
+        "a",
+        "a/abcdef",
+        "a/abcdef/g",
+        "a/abcdef/g/h",
+        "a/abcfed",
+        "a/abcfed/g",
+        "a/abcfed/g/h",
+        "a/b",
+        "a/b/c",
+        "a/b/c/d",
+        "a/bc",
+        "a/bc/e",
+        "a/bc/e/f",
+        "a/c",
+        "a/c/d",
+        "a/c/d/c",
+        "a/c/d/c/b",
+        "a/cb",
+        "a/cb/e",
+        "a/cb/e/f",
+        "a/symlink",
+        "a/symlink/a",
+        "a/symlink/a/b",
+        "a/symlink/a/b/c",
+        "a/x",
+        "a/z",
+      ];
+      if (process.platform === "win32") {
+        expectedFiles = expectedFiles.filter(
+          (path) => path.indexOf("/symlink") === -1,
+        );
+      }
 
-    const pattern = "a/**";
-    glob("fixtures", { pattern }, (er, matches) => {
-      expect(er).toBeFalsy();
-      expect(matches).toEqual(expectedFiles);
-      done();
+      const pattern = "a/**";
+      glob("fixtures", { pattern }, (er, matches) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(matches, expectedFiles);
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/error-callback.test.ts
+++ b/packages/readdir-glob/tests/error-callback.test.ts
@@ -4,7 +4,7 @@ import { describe, it, beforeEach, mock } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
-describe.skip("error-callack", () => {
+describe.skip("error-callback", () => {
   let logCalled = undefined;
   beforeEach(() => {
     logCalled = [];

--- a/packages/readdir-glob/tests/error-callback.test.ts
+++ b/packages/readdir-glob/tests/error-callback.test.ts
@@ -1,28 +1,31 @@
-import { it, beforeEach, describe, expect, spyOn } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { describe, it, beforeEach, mock } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
-describe.todo("error-callack", () => {
+describe.skip("error-callack", () => {
   let logCalled = undefined;
   beforeEach(() => {
     logCalled = [];
-    spyOn(fs, "readdir").mockImplementation((path, opts, cb) => {
+    mock.method(fs, "readdir", (path, opts, cb) => {
       process.nextTick(() => cb(new Error("mock fs.readdir error")));
     });
-    spyOn(console, "error").mockImplementation(function (...args) {
+    mock.method(console, "error", function (...args) {
       args.forEach((arg) => logCalled.push(arg));
     });
   });
 
-  it("error callback", (done) => {
-    glob(".", { pattern: "*" }, (err) => {
-      expect(err).toBeTruthy();
+  it("error callback", async () => {
+    await new Promise<void>((resolve) => {
+      glob(".", { pattern: "*" }, (err) => {
+        assert.ok(err);
 
-      setTimeout(() => {
-        expect(logCalled.length).toBe(1);
-        expect(logCalled[0].message).toEqual("mock fs.readdir error");
-        done();
+        setTimeout(() => {
+          assert.strictEqual(logCalled.length, 1);
+          assert.strictEqual(logCalled[0].message, "mock fs.readdir error");
+          resolve();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/extglob-dotfile.test.ts
+++ b/packages/readdir-glob/tests/extglob-dotfile.test.ts
@@ -1,4 +1,5 @@
-import { it, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -10,13 +11,15 @@ import glob from "@archiver/readdir-glob";
  * deliberate in the pattern.
  */
 describe("extglob-dotfile", () => {
-  it("positive extglob @(.y) should match the explicit dotfile segment with dot:false", (done) => {
-    process.chdir(`${__dirname}/fixtures`);
+  it("positive extglob @(.y) should match the explicit dotfile segment with dot:false", async () => {
+    await new Promise<void>((resolve) => {
+      process.chdir(`${__dirname}/fixtures`);
 
-    glob(".", { pattern: "a/x/@(.y)/b", dot: false }, (er, res) => {
-      expect(er).toBeFalsy();
-      expect(res).toEqual(["a/x/.y/b"]);
-      done();
+      glob(".", { pattern: "a/x/@(.y)/b", dot: false }, (er, res) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(res, ["a/x/.y/b"]);
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/follow.test.ts
+++ b/packages/readdir-glob/tests/follow.test.ts
@@ -1,4 +1,5 @@
-import { it, beforeEach, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -9,21 +10,25 @@ describe("follow", () => {
     process.chdir(`${__dirname}/fixtures`);
   });
 
-  it.skipIf(win32)("follow symlinks", (done) => {
-    const pattern = "a/symlink/**";
-    const long = "a/symlink/a/b/c/c/d";
+  const _it = win32 ? it.skip : it;
 
-    glob(".", { pattern }, (er, res) => {
-      expect(er).toBeFalsy();
-      const noFollow = res.sort();
-      expect(noFollow).not.toContain(long);
+  _it("follow symlinks", async () => {
+    await new Promise<void>((resolve) => {
+      const pattern = "a/symlink/**";
+      const long = "a/symlink/a/b/c/c/d";
 
-      glob(".", { follow: true, pattern }, (er, res) => {
-        expect(er).toBeFalsy();
-        const follow = res.sort();
+      glob(".", { pattern }, (er, res) => {
+        assert.ok(!er);
+        const noFollow = res.sort();
+        assert.ok(!noFollow.includes(long));
 
-        expect(follow).toContain(long);
-        done();
+        glob(".", { follow: true, pattern }, (er, res) => {
+          assert.ok(!er);
+          const follow = res.sort();
+
+          assert.ok(follow.includes(long));
+          resolve();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/globstar-match.test.ts
+++ b/packages/readdir-glob/tests/globstar-match.test.ts
@@ -1,23 +1,26 @@
-import { it, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
 import { readdirGlob } from "@archiver/readdir-glob";
 
 describe("globstar-match", () => {
-  it("globstar should not have dupe matches", (done) => {
-    const pattern = "a/**/[gh]";
-    let cb;
-    const cbSet = new Promise<string[]>((resolve) => (cb = resolve));
-    const g = readdirGlob(".", { cwd: __dirname, pattern }, (_, matches) =>
-      cb(matches),
-    );
-    const matches: string[] = [];
-    g.on("match", (m) => matches.push(m.relative));
-    g.on("end", () => {
-      cbSet.then((set) => {
-        matches.sort();
-        set.sort();
-        expect(matches).toEqual(set);
-        done();
+  it("globstar should not have dupe matches", async () => {
+    await new Promise<void>((done) => {
+      const pattern = "a/**/[gh]";
+      let cb;
+      const cbSet = new Promise<string[]>((resolve) => (cb = resolve));
+      const g = readdirGlob(".", { cwd: __dirname, pattern }, (_, matches) =>
+        cb(matches),
+      );
+      const matches: string[] = [];
+      g.on("match", (m) => matches.push(m.relative));
+      g.on("end", () => {
+        cbSet.then((set) => {
+          matches.sort();
+          set.sort();
+          assert.deepStrictEqual(matches, set);
+          done();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/hooks.ts
+++ b/packages/readdir-glob/tests/hooks.ts
@@ -1,10 +1,10 @@
-import { afterAll, afterEach, beforeAll } from "bun:test";
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as fsPromises from "node:fs/promises";
 // just a little pre-run script to set up the fixtures.
 // zz-finish cleans it up
 import * as path from "node:path";
+import { after, afterEach, before } from "node:test";
 
 function cleanResults(m: string[]) {
   // normalize discrepancies in ordering, duplication,
@@ -32,7 +32,7 @@ function alphasort(a: string, b: string) {
   return a > b ? 1 : a < b ? -1 : 0;
 }
 
-beforeAll(async () => {
+before(async () => {
   const fixtureDir = path.resolve(__dirname, "fixtures");
 
   let files = [
@@ -139,7 +139,7 @@ beforeAll(async () => {
   await fsPromises.writeFile(fname, data);
 });
 
-afterAll(async () => {
+after(async () => {
   await new Promise((resolve) =>
     fs.rm(
       path.resolve(__dirname, "fixtures"),

--- a/packages/readdir-glob/tests/ignore.test.ts
+++ b/packages/readdir-glob/tests/ignore.test.ts
@@ -304,7 +304,7 @@ describe("ignore", () => {
       opt = {};
     }
 
-    const matches = [];
+    const matches: string[] = [];
     opt.ignore = ignore;
 
     it(name, async () => {
@@ -319,11 +319,9 @@ describe("ignore", () => {
               (f) => f.indexOf("symlink") === -1,
             );
           }
-          res.sort();
-          matches.sort();
 
-          assert.deepStrictEqual(res, expectedFiles);
-          assert.deepStrictEqual(matches, expectedFiles);
+          assert.deepStrictEqual(res?.toSorted(), expectedFiles);
+          assert.deepStrictEqual(matches.toSorted(), expectedFiles);
           resolve();
         }).on("match", (p) => matches.push(p.relative));
       });

--- a/packages/readdir-glob/tests/ignore.test.ts
+++ b/packages/readdir-glob/tests/ignore.test.ts
@@ -1,4 +1,5 @@
-import { it, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -306,24 +307,26 @@ describe("ignore", () => {
     const matches = [];
     opt.ignore = ignore;
 
-    it(name, (done) => {
-      process.chdir(`${__dirname}/fixtures`);
+    it(name, async () => {
+      await new Promise<void>((resolve) => {
+        process.chdir(`${__dirname}/fixtures`);
 
-      glob(opt.cwd || ".", { ...opt, pattern }, (er, res) => {
-        expect(er).toBeFalsy();
+        glob(opt.cwd || ".", { ...opt, pattern }, (er, res) => {
+          assert.ok(!er);
 
-        if (process.platform === "win32") {
-          expectedFiles = expectedFiles.filter(
-            (f) => f.indexOf("symlink") === -1,
-          );
-        }
-        res.sort();
-        matches.sort();
+          if (process.platform === "win32") {
+            expectedFiles = expectedFiles.filter(
+              (f) => f.indexOf("symlink") === -1,
+            );
+          }
+          res.sort();
+          matches.sort();
 
-        expect(res).toEqual(expectedFiles);
-        expect(matches).toEqual(expectedFiles);
-        done();
-      }).on("match", (p) => matches.push(p.relative));
+          assert.deepStrictEqual(res, expectedFiles);
+          assert.deepStrictEqual(matches, expectedFiles);
+          resolve();
+        }).on("match", (p) => matches.push(p.relative));
+      });
     });
   });
 
@@ -339,19 +342,21 @@ describe("ignore", () => {
             cwd,
           };
           const expectedFiles = ignore ? [] : ["fixtures/a"];
-          it("race condition: " + JSON.stringify(opt), (done) => {
-            let cb;
-            const cbSet = new Promise((resolve, _) => (cb = resolve));
-            process.chdir(__dirname);
-            glob(cwd, { ...opt, pattern }, (_, matches) => cb(matches)).on(
-              "end",
-              () => {
-                cbSet.then((res) => {
-                  expect(res).toEqual(expectedFiles);
-                  done();
-                });
-              },
-            );
+          it("race condition: " + JSON.stringify(opt), async () => {
+            await new Promise<void>((resolve) => {
+              let cb;
+              const cbSet = new Promise((resolve, _) => (cb = resolve));
+              process.chdir(__dirname);
+              glob(cwd, { ...opt, pattern }, (_, matches) => cb(matches)).on(
+                "end",
+                () => {
+                  cbSet.then((res) => {
+                    assert.deepStrictEqual(res, expectedFiles);
+                    resolve();
+                  });
+                },
+              );
+            });
           });
         });
       });

--- a/packages/readdir-glob/tests/mark.test.ts
+++ b/packages/readdir-glob/tests/mark.test.ts
@@ -1,164 +1,177 @@
-import { it, beforeEach, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
 describe("mark", () => {
   beforeEach(() => {
-    process.chdir(__dirname + "/fixtures");
+    process.chdir(`${__dirname}/fixtures`);
   });
 
-  it("mark with cwd", (done) => {
-    const pattern = "*/*";
-    const opt = { mark: true };
-    glob("a", { ...opt, pattern }, (er, res) => {
-      expect(er).toBeFalsy();
+  it("mark with cwd", async () => {
+    await new Promise<void>((resolve) => {
+      const pattern = "*/*";
+      const opt = { mark: true };
+      glob("a", { ...opt, pattern }, (er, res) => {
+        assert.ok(!er);
 
-      const expected = [
-        "abcdef/g/",
-        "abcfed/g/",
-        "b/c/",
-        "bc/e/",
-        "c/d/",
-        "cb/e/",
-      ];
+        const expected = [
+          "abcdef/g/",
+          "abcfed/g/",
+          "b/c/",
+          "bc/e/",
+          "c/d/",
+          "cb/e/",
+        ];
 
-      if (process.platform !== "win32") {
-        expected.push("symlink/a/");
-      }
+        if (process.platform !== "win32") {
+          expected.push("symlink/a/");
+        }
 
-      expect(res?.toSorted()).toEqual(expected.toSorted());
-      done();
+        assert.deepStrictEqual(res?.toSorted(), expected.toSorted());
+        resolve();
+      });
     });
   });
 
-  it("mark, with **", (done) => {
-    const pattern = "a/*b*/**";
-    const opt = { mark: true };
-    glob(".", { ...opt, pattern }, (er, results) => {
-      expect(er).toBeFalsy();
-      const expected = [
-        "a/abcdef/",
-        "a/abcdef/g/",
-        "a/abcdef/g/h",
-        "a/abcfed/",
-        "a/abcfed/g/",
-        "a/abcfed/g/h",
-        "a/b/",
-        "a/b/c/",
-        "a/b/c/d",
-        "a/bc/",
-        "a/bc/e/",
-        "a/bc/e/f",
-        "a/cb/",
-        "a/cb/e/",
-        "a/cb/e/f",
-      ];
+  it("mark, with **", async () => {
+    await new Promise<void>((resolve) => {
+      const pattern = "a/*b*/**";
+      const opt = { mark: true };
+      glob(".", { ...opt, pattern }, (er, results) => {
+        assert.ok(!er);
+        const expected = [
+          "a/abcdef/",
+          "a/abcdef/g/",
+          "a/abcdef/g/h",
+          "a/abcfed/",
+          "a/abcfed/g/",
+          "a/abcfed/g/h",
+          "a/b/",
+          "a/b/c/",
+          "a/b/c/d",
+          "a/bc/",
+          "a/bc/e/",
+          "a/bc/e/f",
+          "a/cb/",
+          "a/cb/e/",
+          "a/cb/e/f",
+        ];
 
-      expect(results?.toSorted()).toEqual(expected.toSorted());
-      done();
+        assert.deepStrictEqual(results?.toSorted(), expected.toSorted());
+        resolve();
+      });
     });
   });
 
-  it("mark, no / on pattern", (done) => {
-    const pattern = "a/*";
-    const opt = { mark: true };
-    glob(".", { ...opt, pattern }, (er, results) => {
-      expect(er).toBeFalsy();
-      const expected = [
-        "a/abcdef/",
-        "a/abcfed/",
-        "a/b/",
-        "a/bc/",
-        "a/c/",
-        "a/cb/",
-        "a/x/",
-        "a/z/",
-      ];
+  it("mark, no / on pattern", async () => {
+    await new Promise<void>((resolve) => {
+      const pattern = "a/*";
+      const opt = { mark: true };
+      glob(".", { ...opt, pattern }, (er, results) => {
+        assert.ok(!er);
+        const expected = [
+          "a/abcdef/",
+          "a/abcfed/",
+          "a/b/",
+          "a/bc/",
+          "a/c/",
+          "a/cb/",
+          "a/x/",
+          "a/z/",
+        ];
 
-      if (process.platform !== "win32") {
-        expected.push("a/symlink/");
-      }
+        if (process.platform !== "win32") {
+          expected.push("a/symlink/");
+        }
 
-      expect(results?.toSorted()).toEqual(expected.toSorted());
-      done();
-    }).on("match", (m) => {
-      expect(m.relative).toMatch(/\/$/);
+        assert.deepStrictEqual(results?.toSorted(), expected.toSorted());
+        resolve();
+      }).on("match", (m) => {
+        assert.ok(m.relative.endsWith("/"));
+      });
     });
   });
 
-  it("mark=false, no / on pattern", (done) => {
-    const pattern = "a/*";
-    glob(".", { pattern }, (er, results) => {
-      expect(er).toBeFalsy();
-      const expected = [
-        "a/abcdef",
-        "a/abcfed",
-        "a/b",
-        "a/bc",
-        "a/c",
-        "a/cb",
-        "a/x",
-        "a/z",
-      ];
+  it("mark=false, no / on pattern", async () => {
+    await new Promise<void>((resolve) => {
+      const pattern = "a/*";
+      glob(".", { pattern }, (er, results) => {
+        assert.ok(!er);
+        const expected = [
+          "a/abcdef",
+          "a/abcfed",
+          "a/b",
+          "a/bc",
+          "a/c",
+          "a/cb",
+          "a/x",
+          "a/z",
+        ];
 
-      if (process.platform !== "win32") {
-        expected.push("a/symlink");
-      }
+        if (process.platform !== "win32") {
+          expected.push("a/symlink");
+        }
 
-      expect(results?.toSorted()).toEqual(expected.toSorted());
-      done();
-    }).on("match", (m) => {
-      expect(m.relative).toMatch(/[^/]$/);
+        assert.deepStrictEqual(results?.toSorted(), expected.toSorted());
+        resolve();
+      }).on("match", (m) => {
+        assert.ok(/[^/]$/.test(m.relative));
+      });
     });
   });
 
-  it("mark=true, / on pattern", (done) => {
-    const pattern = "a/*/";
-    const opt = { mark: true };
-    glob(".", { ...opt, pattern }, (er, results) => {
-      expect(er).toBeFalsy();
-      const expected = [
-        "a/abcdef/",
-        "a/abcfed/",
-        "a/b/",
-        "a/bc/",
-        "a/c/",
-        "a/cb/",
-        "a/x/",
-        "a/z/",
-      ];
+  it("mark=true, / on pattern", async () => {
+    await new Promise<void>((resolve) => {
+      const pattern = "a/*/";
+      const opt = { mark: true };
+      glob(".", { ...opt, pattern }, (er, results) => {
+        assert.ok(!er);
+        const expected = [
+          "a/abcdef/",
+          "a/abcfed/",
+          "a/b/",
+          "a/bc/",
+          "a/c/",
+          "a/cb/",
+          "a/x/",
+          "a/z/",
+        ];
 
-      if (process.platform !== "win32") {
-        expected.push("a/symlink/");
-      }
+        if (process.platform !== "win32") {
+          expected.push("a/symlink/");
+        }
 
-      expect(results?.toSorted()).toEqual(expected.toSorted());
-      done();
-    }).on("match", (m) => {
-      expect(m.relative).toMatch(/\/$/);
+        assert.deepStrictEqual(results?.toSorted(), expected.toSorted());
+        resolve();
+      }).on("match", (m) => {
+        assert.ok(m.relative.endsWith("/"));
+      });
     });
   });
 
-  it("mark=false, / on pattern", (done) => {
-    const pattern = "a/*/";
-    glob(".", { pattern }, (er, results) => {
-      expect(er).toBeFalsy();
-      const expected = [
-        "a/abcdef",
-        "a/abcfed",
-        "a/b",
-        "a/bc",
-        "a/c",
-        "a/cb",
-        "a/x",
-        "a/z",
-      ];
-      if (process.platform !== "win32") {
-        expected.push("a/symlink");
-      }
+  it("mark=false, / on pattern", async () => {
+    await new Promise<void>((resolve) => {
+      const pattern = "a/*/";
+      glob(".", { pattern }, (er, results) => {
+        assert.ok(!er);
+        const expected = [
+          "a/abcdef",
+          "a/abcfed",
+          "a/b",
+          "a/bc",
+          "a/c",
+          "a/cb",
+          "a/x",
+          "a/z",
+        ];
+        if (process.platform !== "win32") {
+          expected.push("a/symlink");
+        }
 
-      expect(results?.toSorted()).toEqual(expected.toSorted());
-      done();
+        assert.deepStrictEqual(results?.toSorted(), expected.toSorted());
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/match-base.test.ts
+++ b/packages/readdir-glob/tests/match-base.test.ts
@@ -1,5 +1,6 @@
-import { it, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
 import * as path from "node:path";
+import { describe, it } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -17,22 +18,26 @@ if (process.platform === "win32") {
 }
 
 describe("match-base", () => {
-  it("chdir", (done) => {
-    const origCwd = process.cwd();
-    process.chdir(fixtureDir);
-    glob(".", { matchBase: true, pattern }, (er, res) => {
-      expect(er).toBeFalsy();
-      expect(res?.toSorted()).toEqual(expected.toSorted());
-      process.chdir(origCwd);
-      done();
+  it("chdir", async () => {
+    await new Promise<void>((resolve) => {
+      const origCwd = process.cwd();
+      process.chdir(fixtureDir);
+      glob(".", { matchBase: true, pattern }, (er, res) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(res?.toSorted(), expected.toSorted());
+        process.chdir(origCwd);
+        resolve();
+      });
     });
   });
 
-  it("cwd", (done) => {
-    glob(fixtureDir, { matchBase: true, pattern }, (er, res) => {
-      expect(er).toBeFalsy();
-      expect(res?.toSorted()).toEqual(expected.toSorted());
-      done();
+  it("cwd", async () => {
+    await new Promise<void>((resolve) => {
+      glob(fixtureDir, { matchBase: true, pattern }, (er, res) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(res?.toSorted(), expected.toSorted());
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/multiple-weird-error.test.ts
+++ b/packages/readdir-glob/tests/multiple-weird-error.test.ts
@@ -1,28 +1,29 @@
-import { it, describe, expect, spyOn } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { describe, it, mock } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
-describe.todo("multiple-weird-error", () => {
+describe.skip("multiple-weird-error", () => {
   // also test that silent:true is actually silent!
-  it("multiple-weird-error", (done) => {
-    spyOn(console, "error").mockImplementation(() => {
-      throw new Error("SILENCE, INSECT!");
-    });
-    spyOn(fs, "readdir").mockImplementation((path, opts, cb) =>
-      cb(new Error("expected")),
-    );
-
-    let count = 0;
-    const max = 2;
-    for (let i = 0; i < max; ++i) {
-      glob(".", { silent: true, pattern: "*" }, function (err) {
-        expect(err).toBeTruthy();
-        count++;
-        if (count === max) {
-          done();
-        }
+  it("multiple-weird-error", async () => {
+    await new Promise<void>((resolve) => {
+      mock.method(console, "error", () => {
+        throw new Error("SILENCE, INSECT!");
       });
-    }
+      mock.method(fs, "readdir", (path, opts, cb) => cb(new Error("expected")));
+
+      let count = 0;
+      const max = 2;
+      for (let i = 0; i < max; ++i) {
+        glob(".", { silent: true, pattern: "*" }, function (err) {
+          assert.ok(err);
+          count++;
+          if (count === max) {
+            resolve();
+          }
+        });
+      }
+    });
   });
 });

--- a/packages/readdir-glob/tests/new-glob-optional-options.test.ts
+++ b/packages/readdir-glob/tests/new-glob-optional-options.test.ts
@@ -1,17 +1,20 @@
-import { it, beforeEach, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 import { readdirGlob } from "@archiver/readdir-glob";
 
 describe("new-glob-optional-options", () => {
   beforeEach(() => {
-    process.chdir(__dirname + "/fixtures");
+    process.chdir(`${__dirname}/fixtures`);
   });
 
-  it("new glob, with cb, and no options", (done) => {
-    readdirGlob("./a/bc/e/", function (er, results) {
-      expect(er).toBeFalsy();
-      expect(results).toEqual(["f"]);
-      done();
+  it("new glob, with cb, and no options", async () => {
+    await new Promise<void>((resolve) => {
+      readdirGlob("./a/bc/e/", function (er, results) {
+        assert.ok(!er);
+        assert.deepStrictEqual(results, ["f"]);
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/nocase-nomagic.test.ts
+++ b/packages/readdir-glob/tests/nocase-nomagic.test.ts
@@ -1,5 +1,6 @@
-import { it, beforeEach, describe, expect, spyOn, afterEach } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -37,86 +38,99 @@ function fakeReaddir(path, opts) {
   return ret;
 }
 
-describe.todo("nocase-nomagic", () => {
+describe.skip("nocase-nomagic", () => {
   let statSpy, lstatSpy, readdirSpy;
 
   beforeEach(() => {
-    const statMock = (path, cb) => {
+    const originalStat = fs.stat;
+    const originalLstat = fs.lstat;
+    const originalRead = fs.readdir;
+
+    statSpy = mock.method(fs, "stat", (path, cb) => {
       const f = fakeStat(path);
       if (f) {
         process.nextTick(() => cb(null, f));
       } else {
-        statSpy.getOriginalImplementation().call(fs, path, cb);
+        originalStat.call(fs, path, cb);
       }
-    };
+    });
 
-    const readdirMock = (path, opts, cb) => {
+    lstatSpy = mock.method(fs, "lstat", (path, cb) => {
+      const f = fakeStat(path);
+      if (f) {
+        process.nextTick(() => cb(null, f));
+      } else {
+        originalLstat.call(fs, path, cb);
+      }
+    });
+
+    readdirSpy = mock.method(fs, "readdir", (path, opts, cb) => {
       const f = fakeReaddir(path, opts);
       if (f) {
         process.nextTick(() => cb(null, f));
       } else {
-        readdirSpy.getOriginalImplementation().call(fs, path, opts, cb);
+        originalRead.call(fs, path, opts, cb);
       }
-    };
-
-    statSpy = spyOn(fs, "stat").mockImplementation(statMock);
-    lstatSpy = spyOn(fs, "lstat").mockImplementation(statMock);
-    readdirSpy = spyOn(fs, "readdir").mockImplementation(readdirMock);
+    });
   });
 
   afterEach(() => {
-    statSpy.mockRestore();
-    lstatSpy.mockRestore();
-    readdirSpy.mockRestore();
+    statSpy.mock.restore();
+    lstatSpy.mock.restore();
+    readdirSpy.mock.restore();
   });
 
-  it("nocase, nomagic", (done) => {
-    let n = 2;
-    const want = [
-      "TMP/A",
-      "TMP/a",
-      "tMP/A",
-      "tMP/a",
-      "tMp/A",
-      "tMp/a",
-      "tmp/A",
-      "tmp/a",
-    ];
-    glob(".", { nocase: true, pattern: "tmp/a" }, (er, res) => {
-      expect(er).toBeFalsy();
-      res.sort();
-      expect(res).toEqual(want);
-      if (--n === 0) {
-        done();
-      }
-    });
-    glob(".", { nocase: true, pattern: "tmp/A" }, (er, res) => {
-      expect(er).toBeFalsy();
-      res.sort();
-      expect(res).toEqual(want);
-      if (--n === 0) {
-        done();
-      }
+  it("nocase, nomagic", async () => {
+    await new Promise<void>((resolve) => {
+      let n = 2;
+      const want = [
+        "TMP/A",
+        "TMP/a",
+        "tMP/A",
+        "tMP/a",
+        "tMp/A",
+        "tMp/a",
+        "tmp/A",
+        "tmp/a",
+      ];
+      glob(".", { nocase: true, pattern: "tmp/a" }, (er, res) => {
+        assert.ok(!er);
+        res.sort();
+        assert.deepStrictEqual(res, want);
+        if (--n === 0) {
+          resolve();
+        }
+      });
+      glob(".", { nocase: true, pattern: "tmp/A" }, (er, res) => {
+        assert.ok(!er);
+        res.sort();
+        assert.deepStrictEqual(res, want);
+        if (--n === 0) {
+          resolve();
+        }
+      });
     });
   });
 
-  it("nocase, with some magic", (done) => {
-    const want = [
-      "TMP/A",
-      "TMP/a",
-      "tMP/A",
-      "tMP/a",
-      "tMp/A",
-      "tMp/a",
-      "tmp/A",
-      "tmp/a",
-    ];
+  it("nocase, with some magic", async () => {
+    await new Promise<void>((resolve) => {
+      const want = [
+        "TMP/A",
+        "TMP/a",
+        "tMP/A",
+        "tMP/a",
+        "tMp/A",
+        "tMp/a",
+        "tmp/A",
+        "tmp/a",
+      ];
 
-    glob(".", { nocase: true, pattern: "tmp/*" }, (er, res) => {
-      expect(er).toBeFalsy();
-      res.sort();
-      expect(res).toEqual(want);
-      done();
+      glob(".", { nocase: true, pattern: "tmp/*" }, (er, res) => {
+        assert.ok(!er);
+        res.sort();
+        assert.deepStrictEqual(res, want);
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/nodir.test.ts
+++ b/packages/readdir-glob/tests/nodir.test.ts
@@ -1,4 +1,5 @@
-import { it, beforeEach, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -39,12 +40,14 @@ describe("nodir", () => {
     if (process.platform === "win32") {
       expected = expected.filter((path) => path.indexOf("symlink") === -1);
     }
-    it(pattern + " " + JSON.stringify(options), (done) => {
-      glob(options.cwd || ".", { pattern, ...options }, (er, res) => {
-        expect(er).toBeFalsy();
-        res.sort();
-        expect(res).toEqual(expected);
-        done();
+    it(pattern + " " + JSON.stringify(options), async () => {
+      await new Promise<void>((resolve) => {
+        glob(options.cwd || ".", { pattern, ...options }, (er, res) => {
+          assert.ok(!er);
+          res.sort();
+          assert.deepStrictEqual(res, expected);
+          resolve();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/noglobstar.test.ts
+++ b/packages/readdir-glob/tests/noglobstar.test.ts
@@ -1,28 +1,31 @@
-import { describe, expect, it } from "bun:test";
+import assert from "node:assert/strict";
 import * as path from "node:path";
+import { describe, it } from "node:test";
 
 import { readdirGlob } from "@archiver/readdir-glob";
 
 describe("noglobstar", () => {
-  it("noglobstar:true — a/** must not match 'a' itself (zero extra segments)", (done) => {
-    const fixtureDir = path.resolve(__dirname, "fixtures");
+  it("noglobstar:true — a/** must not match 'a' itself (zero extra segments)", async () => {
+    await new Promise<void>((resolve) => {
+      const fixtureDir = path.resolve(__dirname, "fixtures");
 
-    readdirGlob(
-      fixtureDir,
-      { pattern: "a/**", noglobstar: true },
-      (err, matches) => {
-        expect(err).toBeNull();
+      readdirGlob(
+        fixtureDir,
+        { pattern: "a/**", noglobstar: true },
+        (err, matches) => {
+          assert.strictEqual(err, null);
 
-        // With noglobstar:true, ** degrades to a single-segment wildcard (*),
-        // so "a/**" is equivalent to "a/*" and requires exactly one additional
-        // segment.  The top-level directory "a" (zero extra segments) must
-        // NOT appear in the results.
-        expect(matches).not.toContain("a"); // ← the regression assertion
+          // With noglobstar:true, ** degrades to a single-segment wildcard (*),
+          // so "a/**" is equivalent to "a/*" and requires exactly one additional
+          // segment.  The top-level directory "a" (zero extra segments) must
+          // NOT appear in the results.
+          assert.ok(!matches.includes("a")); // ← the regression assertion
 
-        // Direct children of "a" are still expected (they satisfy "a/*").
-        expect(matches).toContain("a/b");
-        done();
-      },
-    );
+          // Direct children of "a" are still expected (they satisfy "a/*").
+          assert.ok(matches.includes("a/b"));
+          resolve();
+        },
+      );
+    });
   });
 });

--- a/packages/readdir-glob/tests/pattern-list.test.ts
+++ b/packages/readdir-glob/tests/pattern-list.test.ts
@@ -1,4 +1,5 @@
-import { it, beforeEach, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -16,12 +17,14 @@ describe("pattern-list", () => {
     const cwd = c[0];
     const options = c[1];
     const expected = c[2].sort();
-    it(cwd + " " + JSON.stringify(options), (done) => {
-      glob(cwd, options, (er, res) => {
-        expect(er).toBeFalsy();
-        res.sort();
-        expect(res).toEqual(expected);
-        done();
+    it(cwd + " " + JSON.stringify(options), async () => {
+      await new Promise<void>((resolve) => {
+        glob(cwd, options, (er, res) => {
+          assert.ok(!er);
+          res.sort();
+          assert.deepStrictEqual(res, expected);
+          resolve();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/pause-resume.test.ts
+++ b/packages/readdir-glob/tests/pause-resume.test.ts
@@ -9,29 +9,32 @@ const pattern = "a/!(symlink)/**";
 
 describe("pause-resume", () => {
   beforeEach(() => {
-    process.chdir(__dirname + "/fixtures");
+    process.chdir(`${__dirname}/fixtures`);
   });
 
-  function alphasort(a, b) {
+  function alphasort(a: string, b: string) {
     a = a.toLowerCase();
     b = b.toLowerCase();
     return a > b ? 1 : a < b ? -1 : 0;
   }
 
-  function cleanResults(m) {
+  function cleanResults(m: string[]) {
     // normalize discrepancies in ordering, duplication,
     // and ending slashes.
     return m.sort(alphasort);
   }
 
   it("use a ReaddirGlob object, and pause/resume it", async () => {
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       let globResults: string[] = [];
 
-      let cb;
-      const cbSet = new Promise((resolve) => (cb = resolve));
+      let cb: (value: string[]) => void;
+      const cbSet = new Promise<string[]>((resolve) => (cb = resolve));
 
-      const g = readdirGlob(".", { pattern }, (_, matches) => cb(matches));
+      const g = readdirGlob(".", { pattern }, (err, matches) => {
+        if (err) return reject(err);
+        cb(matches);
+      });
       const expected = bashResults[pattern];
 
       g.on("match", (m) => {
@@ -43,13 +46,15 @@ describe("pause-resume", () => {
       });
 
       g.on("end", () => {
-        cbSet.then((matches) => {
-          globResults = cleanResults(globResults);
-          matches = cleanResults(matches);
-          assert.deepStrictEqual(matches, globResults);
-          assert.deepStrictEqual(matches, expected);
-          resolve();
-        });
+        cbSet
+          .then((matches) => {
+            globResults = cleanResults(globResults);
+            matches = cleanResults(matches);
+            assert.deepStrictEqual(matches, globResults);
+            assert.deepStrictEqual(matches, expected);
+            resolve();
+          })
+          .catch(reject);
       });
     });
   });

--- a/packages/readdir-glob/tests/pause-resume.test.ts
+++ b/packages/readdir-glob/tests/pause-resume.test.ts
@@ -1,4 +1,5 @@
-import { it, beforeEach, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 import { readdirGlob } from "@archiver/readdir-glob";
 
@@ -23,30 +24,32 @@ describe("pause-resume", () => {
     return m.sort(alphasort);
   }
 
-  it("use a ReaddirGlob object, and pause/resume it", (done) => {
-    let globResults: string[] = [];
+  it("use a ReaddirGlob object, and pause/resume it", async () => {
+    await new Promise<void>((resolve) => {
+      let globResults: string[] = [];
 
-    let cb;
-    const cbSet = new Promise((resolve) => (cb = resolve));
+      let cb;
+      const cbSet = new Promise((resolve) => (cb = resolve));
 
-    const g = readdirGlob(".", { pattern }, (_, matches) => cb(matches));
-    const expected = bashResults[pattern];
+      const g = readdirGlob(".", { pattern }, (_, matches) => cb(matches));
+      const expected = bashResults[pattern];
 
-    g.on("match", (m) => {
-      expect(g.paused).toBeFalsy();
-      globResults.push(m.relative);
-      g.pause();
-      expect(g.paused).toBeTruthy();
-      setTimeout(g.resume.bind(g), 10);
-    });
+      g.on("match", (m) => {
+        assert.ok(!g.paused);
+        globResults.push(m.relative);
+        g.pause();
+        assert.ok(g.paused);
+        setTimeout(g.resume.bind(g), 10);
+      });
 
-    g.on("end", () => {
-      cbSet.then((matches) => {
-        globResults = cleanResults(globResults);
-        matches = cleanResults(matches);
-        expect(matches).toEqual(globResults);
-        expect(matches).toEqual(expected);
-        done();
+      g.on("end", () => {
+        cbSet.then((matches) => {
+          globResults = cleanResults(globResults);
+          matches = cleanResults(matches);
+          assert.deepStrictEqual(matches, globResults);
+          assert.deepStrictEqual(matches, expected);
+          resolve();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/readme-issue.test.ts
+++ b/packages/readdir-glob/tests/readme-issue.test.ts
@@ -1,5 +1,6 @@
-import { it, beforeEach, describe, expect, afterEach } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { describe, it, beforeEach, afterEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -16,17 +17,19 @@ describe("readme-issue", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("glob", (done) => {
-    const opt = {
-      pattern: "README?(.*)",
-      nocase: true,
-      mark: true,
-    };
+  it("glob", async () => {
+    await new Promise<void>((resolve) => {
+      const opt = {
+        pattern: "README?(.*)",
+        nocase: true,
+        mark: true,
+      };
 
-    glob(dir, opt, (er, files) => {
-      expect(er).toBeFalsy();
-      expect(files).toEqual(["README"]);
-      done();
+      glob(dir, opt, (er, files) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(files, ["README"]);
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/realpath.test.ts
+++ b/packages/readdir-glob/tests/realpath.test.ts
@@ -1,5 +1,6 @@
-import { it, beforeEach, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
 import * as path from "node:path";
+import { describe, it, beforeEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -31,26 +32,30 @@ describe("realpath", () => {
     [{ cwd: "a" }, [], "no one here but us chickens"],
   ];
 
+  const _it = win32 ? it.skip : it;
+
   cases.forEach((c) => {
     const opt = c[0];
 
-    it.skipIf(win32)(JSON.stringify(c), (done) => {
-      let expected = c[1];
-      if (!(opt.nonull && expected[0].match(/^no one here/))) {
-        expected = expected.map((d) => {
-          d = (opt.cwd ? path.resolve(opt.cwd) : fixtureDir) + "/" + d;
-          return d.replace(/\\/g, "/");
+    _it(JSON.stringify(c), async () => {
+      await new Promise<void>((resolve) => {
+        let expected = c[1];
+        if (!(opt.nonull && expected[0].match(/^no one here/))) {
+          expected = expected.map((d) => {
+            d = (opt.cwd ? path.resolve(opt.cwd) : fixtureDir) + "/" + d;
+            return d.replace(/\\/g, "/");
+          });
+        }
+        const p = c[2] || pattern;
+
+        opt.absolute = true;
+        opt.pattern = p;
+
+        glob(opt.cwd || ".", opt, function (er, async) {
+          assert.ok(!er);
+          assert.deepStrictEqual(async, expected);
+          resolve();
         });
-      }
-      const p = c[2] || pattern;
-
-      opt.absolute = true;
-      opt.pattern = p;
-
-      glob(opt.cwd || ".", opt, function (er, async) {
-        expect(er).toBeFalsy();
-        expect(async).toEqual(expected);
-        done();
       });
     });
   });

--- a/packages/readdir-glob/tests/removed-files.test.ts
+++ b/packages/readdir-glob/tests/removed-files.test.ts
@@ -1,5 +1,6 @@
-import { it, beforeEach, describe, expect, afterEach } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { describe, it, beforeEach, afterEach } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
@@ -8,8 +9,8 @@ const dir = __dirname + "/removed-files";
 describe("removed-files", () => {
   beforeEach(() => {
     fs.mkdirSync(dir, { recursive: true });
-    fs.mkdirSync(dir + "/b", { recursive: true });
-    fs.mkdirSync(dir + "/a", { recursive: true });
+    fs.mkdirSync(`${dir}/b`, { recursive: true });
+    fs.mkdirSync(`${dir}/a`, { recursive: true });
     fs.writeFileSync(dir + "/a/a.txt", "a", "ascii");
     fs.writeFileSync(dir + "/a/b.txt", "b", "ascii");
   });
@@ -18,38 +19,42 @@ describe("removed-files", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("removed file during exploration", (done) => {
-    const g = glob(dir, { stat: true });
-    const files: string[] = [];
+  it("removed file during exploration", async () => {
+    await new Promise<void>((resolve) => {
+      const g = glob(dir, { stat: true });
+      const files: string[] = [];
 
-    g.on("match", (match) => {
-      if (/a\/.+/.test(match.relative)) {
-        fs.rmSync(dir + "/a", { recursive: true, force: true });
-        files.push(match.relative);
-      }
-    });
+      g.on("match", (match) => {
+        if (/a\/.+/.test(match.relative)) {
+          fs.rmSync(`${dir}/a`, { recursive: true, force: true });
+          files.push(match.relative);
+        }
+      });
 
-    g.on("end", () => {
-      expect(files.sort()).toEqual(["a/a.txt", "a/b.txt"]);
-      done();
+      g.on("end", () => {
+        assert.deepStrictEqual(files.sort(), ["a/a.txt", "a/b.txt"]);
+        resolve();
+      });
     });
   });
 
-  it("folder turned into a file during exploration", (done) => {
-    const g = glob(dir, { stat: true });
-    const files: string[] = [];
+  it("folder turned into a file during exploration", async () => {
+    await new Promise<void>((resolve) => {
+      const g = glob(dir, { stat: true });
+      const files: string[] = [];
 
-    g.on("match", (match) => {
-      if (match.relative === "a") {
-        fs.rmSync(dir + "/a", { recursive: true, force: true });
-        fs.writeFileSync(dir + "/a", "oops", "ascii");
-      }
-      files.push(match.relative);
-    });
+      g.on("match", (match) => {
+        if (match.relative === "a") {
+          fs.rmSync(`${dir}/a`, { recursive: true, force: true });
+          fs.writeFileSync(`${dir}/a`, "oops", "ascii");
+        }
+        files.push(match.relative);
+      });
 
-    g.on("end", () => {
-      expect(files.sort()).toEqual(["a", "b"]);
-      done();
+      g.on("end", () => {
+        assert.deepStrictEqual(files.sort(), ["a", "b"]);
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/skip.test.ts
+++ b/packages/readdir-glob/tests/skip.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 import glob, { type Options } from "@archiver/readdir-glob";
 
@@ -74,11 +75,13 @@ describe("skip", () => {
     if (process.platform === "win32") {
       expected = expected.filter((path) => path.indexOf("symlink") === -1);
     }
-    it(cwd + " " + JSON.stringify(options), (done) => {
-      glob(cwd, options, (er, res) => {
-        expect(er).toBeFalsy();
-        expect(res?.toSorted()).toEqual(expected);
-        done();
+    it(cwd + " " + JSON.stringify(options), async () => {
+      await new Promise<void>((resolve) => {
+        glob(cwd, options, (er, res) => {
+          assert.ok(!er);
+          assert.deepStrictEqual(res?.toSorted(), expected);
+          resolve();
+        });
       });
     });
   });

--- a/packages/readdir-glob/tests/slash-cwd.test.ts
+++ b/packages/readdir-glob/tests/slash-cwd.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, it, describe, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 // regression test to make sure that slash-ended patterns
 // don't match files when using a different cwd.
@@ -9,14 +10,16 @@ const expected = ["tests/"];
 
 describe("slash-cwd", () => {
   beforeEach(() => {
-    process.chdir(__dirname + "/..");
+    process.chdir(`${__dirname}/..`);
   });
 
-  it("slashes only match directories", (done) => {
-    glob(".", { mark: true, pattern }, (er, async) => {
-      expect(er).toBeFalsy();
-      expect(async).toEqual(expected);
-      done();
+  it("slashes only match directories", async () => {
+    await new Promise<void>((resolve) => {
+      glob(".", { mark: true, pattern }, (er, async) => {
+        assert.ok(!er);
+        assert.deepStrictEqual(async, expected);
+        resolve();
+      });
     });
   });
 });

--- a/packages/readdir-glob/tests/stat.test.ts
+++ b/packages/readdir-glob/tests/stat.test.ts
@@ -1,51 +1,55 @@
-import { describe, it, expect } from "bun:test";
+import assert from "node:assert/strict";
 import { Stats } from "node:fs";
+import { describe, it } from "node:test";
 
 import glob from "@archiver/readdir-glob";
 
 const dir = `${import.meta.dirname}/fixtures`;
 
 describe("stat", () => {
-  it("stat all the things", (done) => {
-    const g = glob(dir, { stat: true, pattern: "a/*abc*/**" });
-    const matches: string[] = [];
-    g.on("match", (m) => {
-      matches.push(m.relative);
-      expect(m.stat).toBeInstanceOf(Stats);
-      expect(m.stat).toHaveProperty("isFile");
-      expect(m.stat).toHaveProperty("isDirectory");
-      expect(m.stat).toHaveProperty("isSymbolicLink");
-      expect(m.stat).toHaveProperty("isBlockDevice");
-      expect(m.stat).toHaveProperty("isCharacterDevice");
-      expect(m.stat).toHaveProperty("isFIFO");
-      expect(m.stat).toHaveProperty("isSocket");
-      expect(m.stat).toHaveProperty("dev");
-      expect(m.stat).toHaveProperty("ino");
-      expect(m.stat).toHaveProperty("mode");
-      expect(m.stat).toHaveProperty("nlink");
-      expect(m.stat).toHaveProperty("uid");
-      expect(m.stat).toHaveProperty("gid");
-      expect(m.stat).toHaveProperty("rdev");
-      expect(m.stat).toHaveProperty("size");
-      expect(m.stat).toHaveProperty("blksize");
-      expect(m.stat).toHaveProperty("blocks");
-      expect(m.stat).toHaveProperty("atimeMs");
-      expect(m.stat).toHaveProperty("mtimeMs");
-      expect(m.stat).toHaveProperty("ctimeMs");
-      expect(m.stat).toHaveProperty("birthtimeMs");
-    });
-    g.on("end", () => {
-      expect(matches.toSorted()).toEqual(
-        [
-          "a/abcdef",
-          "a/abcdef/g",
-          "a/abcdef/g/h",
-          "a/abcfed",
-          "a/abcfed/g",
-          "a/abcfed/g/h",
-        ].toSorted(),
-      );
-      done();
+  it("stat all the things", async () => {
+    await new Promise<void>((resolve) => {
+      const g = glob(dir, { stat: true, pattern: "a/*abc*/**" });
+      const matches: string[] = [];
+      g.on("match", (m) => {
+        matches.push(m.relative);
+        assert.ok(m.stat instanceof Stats);
+        assert.ok("isFile" in m.stat);
+        assert.ok("isDirectory" in m.stat);
+        assert.ok("isSymbolicLink" in m.stat);
+        assert.ok("isBlockDevice" in m.stat);
+        assert.ok("isCharacterDevice" in m.stat);
+        assert.ok("isFIFO" in m.stat);
+        assert.ok("isSocket" in m.stat);
+        assert.ok("dev" in m.stat);
+        assert.ok("ino" in m.stat);
+        assert.ok("mode" in m.stat);
+        assert.ok("nlink" in m.stat);
+        assert.ok("uid" in m.stat);
+        assert.ok("gid" in m.stat);
+        assert.ok("rdev" in m.stat);
+        assert.ok("size" in m.stat);
+        assert.ok("blksize" in m.stat);
+        assert.ok("blocks" in m.stat);
+        assert.ok("atimeMs" in m.stat);
+        assert.ok("mtimeMs" in m.stat);
+        assert.ok("ctimeMs" in m.stat);
+        assert.ok("birthtimeMs" in m.stat);
+      });
+      g.on("end", () => {
+        assert.deepStrictEqual(
+          matches.toSorted(),
+          [
+            "a/abcdef",
+            "a/abcdef/g",
+            "a/abcdef/g/h",
+            "a/abcfed",
+            "a/abcfed/g",
+            "a/abcfed/g/h",
+          ].toSorted(),
+        );
+        resolve();
+      });
     });
   });
 });

--- a/packages/tar-stream/tests/dual.test.ts
+++ b/packages/tar-stream/tests/dual.test.ts
@@ -1,4 +1,5 @@
-import { test, expect } from "bun:test";
+import assert from "node:assert/strict";
+import { test } from "node:test";
 
 import * as tar from "../src/index";
 import { Readable } from "../src/lib/streamx";
@@ -15,13 +16,13 @@ test("write and read huge archive", () => {
     });
 
     stream.on("end", function () {
-      expect(size).toBe(header.size);
+      assert.strictEqual(size, header.size);
       next();
     });
   });
 
   pack.pipe(extract, function (err) {
-    expect(!err).toBeTrue();
+    assert.ok(!err);
   });
 
   const entry = pack.entry({

--- a/packages/tar-stream/tests/extract.test.ts
+++ b/packages/tar-stream/tests/extract.test.ts
@@ -1,5 +1,6 @@
-import { test, expect } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { test } from "node:test";
 
 import concat from "es-concat-stream";
 
@@ -11,7 +12,7 @@ test("one-file", () => {
   let noEntries = false;
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "test.txt",
       mode: 0o644,
       uid: 501,
@@ -30,14 +31,14 @@ test("one-file", () => {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("hello world\n");
+        assert.strictEqual(data.toString(), "hello world\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.ONE_FILE_TAR));
@@ -48,7 +49,7 @@ test("chunked-one-file", function () {
   let noEntries = false;
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "test.txt",
       mode: 0o644,
       uid: 501,
@@ -67,14 +68,14 @@ test("chunked-one-file", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("hello world\n");
+        assert.strictEqual(data.toString(), "hello world\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   const b = fs.readFileSync(fixtures.ONE_FILE_TAR);
@@ -92,13 +93,13 @@ test("multi-file", function () {
   extract.once("entry", onfile1);
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.MULTI_FILE_TAR));
 
   function onfile1(header: unknown, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "file-1.txt",
       mode: 0o644,
       uid: 501,
@@ -117,14 +118,14 @@ test("multi-file", function () {
     extract.on("entry", onfile2);
     stream.pipe(
       concat(function (data) {
-        expect(data.toString()).toBe("i am file-1\n");
+        assert.strictEqual(data.toString(), "i am file-1\n");
         cb();
       }),
     );
   }
 
   function onfile2(header: unknown, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "file-2.txt",
       mode: 0o644,
       uid: 501,
@@ -143,7 +144,7 @@ test("multi-file", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("i am file-2\n");
+        assert.strictEqual(data.toString(), "i am file-2\n");
         cb();
       }),
     );
@@ -157,7 +158,7 @@ test("chunked-multi-file", function () {
   extract.once("entry", onfile1);
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   const b = fs.readFileSync(fixtures.MULTI_FILE_TAR);
@@ -167,7 +168,7 @@ test("chunked-multi-file", function () {
   extract.end();
 
   function onfile1(header: unknown, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "file-1.txt",
       mode: 0o644,
       uid: 501,
@@ -186,14 +187,14 @@ test("chunked-multi-file", function () {
     extract.on("entry", onfile2);
     stream.pipe(
       concat(function (data) {
-        expect(data.toString()).toBe("i am file-1\n");
+        assert.strictEqual(data.toString(), "i am file-1\n");
         cb();
       }),
     );
   }
 
   function onfile2(header: unknown, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "file-2.txt",
       mode: 0o644,
       uid: 501,
@@ -212,7 +213,7 @@ test("chunked-multi-file", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("i am file-2\n");
+        assert.strictEqual(data.toString(), "i am file-2\n");
         cb();
       }),
     );
@@ -224,7 +225,7 @@ test("pax", function () {
   let noEntries = false;
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "pax.txt",
       mode: 0o644,
       uid: 501,
@@ -243,14 +244,14 @@ test("pax", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("hello world\n");
+        assert.strictEqual(data.toString(), "hello world\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.PAX_TAR));
@@ -263,13 +264,13 @@ test("types", function () {
   extract.once("entry", ondir);
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.TYPES_TAR));
 
   function ondir(header: unknown, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "directory",
       mode: 0o755,
       uid: 501,
@@ -285,17 +286,17 @@ test("types", function () {
       pax: null,
     });
     stream.on("data", function () {
-      expect.unreachable();
+      assert.fail();
     });
     stream.on("end", function () {
-      expect().pass("ended");
+      assert.ok(true);
     });
     extract.once("entry", onlink);
     cb();
   }
 
   function onlink(header: unknown, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "directory-link",
       mode: 0o755,
       uid: 501,
@@ -311,10 +312,10 @@ test("types", function () {
       pax: null,
     });
     stream.on("data", function () {
-      expect.unreachable();
+      assert.fail();
     });
     stream.on("end", function () {
-      expect().pass("ended");
+      assert.ok(true);
     });
     noEntries = true;
     cb();
@@ -326,7 +327,7 @@ test("long-name", function () {
   let noEntries = false;
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "my/file/is/longer/than/100/characters/and/should/use/the/prefix/header/foobarbaz/foobarbaz/foobarbaz/foobarbaz/foobarbaz/foobarbaz/filename.txt",
       mode: 0o644,
       uid: 501,
@@ -345,14 +346,14 @@ test("long-name", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("hello long name\n");
+        assert.strictEqual(data.toString(), "hello long name\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.LONG_NAME_TAR));
@@ -365,7 +366,7 @@ test("unicode-bsd", function () {
   let noEntries = false;
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "høllø.txt",
       mode: 0o644,
       uid: 501,
@@ -391,14 +392,14 @@ test("unicode-bsd", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("hej\n");
+        assert.strictEqual(data.toString(), "hej\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.UNICODE_BSD_TAR));
@@ -411,7 +412,7 @@ test("unicode", function () {
   let noEntries = false;
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "høstål.txt",
       mode: 0o644,
       uid: 501,
@@ -430,14 +431,14 @@ test("unicode", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("høllø\n");
+        assert.strictEqual(data.toString(), "høllø\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.UNICODE_TAR));
@@ -447,18 +448,18 @@ test("name-is-100", function () {
   const extract = tar.extract();
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header.name.length).toBe(100);
+    assert.strictEqual(header.name.length, 100);
 
     stream.pipe(
       concat(function (data) {
-        expect(data.toString()).toBe("hello\n");
+        assert.strictEqual(data.toString(), "hello\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect().pass();
+    assert.ok(true);
   });
 
   extract.end(fs.readFileSync(fixtures.NAME_IS_100_TAR));
@@ -468,7 +469,7 @@ test("invalid-file", function () {
   const extract = tar.extract();
 
   extract.on("error", function (err) {
-    expect(!!err).toBeTrue();
+    assert.ok(err);
     extract.destroy();
   });
 
@@ -479,12 +480,12 @@ test("space prefixed", function () {
   const extract = tar.extract();
 
   extract.on("entry", function (header, stream, cb) {
-    expect().pass();
+    assert.ok(true);
     cb();
   });
 
   extract.on("finish", function () {
-    expect().pass();
+    assert.ok(true);
   });
 
   extract.end(fs.readFileSync(fixtures.SPACE_TAR_GZ));
@@ -494,12 +495,12 @@ test("gnu long path", function () {
   const extract = tar.extract();
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header.name.length).toBeGreaterThan(100);
+    assert.ok(header.name.length > 100);
     cb();
   });
 
   extract.on("finish", function () {
-    expect().pass();
+    assert.ok(true);
   });
 
   extract.end(fs.readFileSync(fixtures.GNU_LONG_PATH));
@@ -509,8 +510,8 @@ test("base 256 uid and gid", function () {
   const extract = tar.extract();
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header.uid).toBe(116435139);
-    expect(header.gid).toBe(1876110778);
+    assert.strictEqual(header.uid, 116435139);
+    assert.strictEqual(header.gid, 1876110778);
     cb();
   });
 
@@ -521,7 +522,7 @@ test("base 256 size", function () {
   const extract = tar.extract();
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "test.txt",
       mode: 0o644,
       uid: 501,
@@ -540,7 +541,7 @@ test("base 256 size", function () {
   });
 
   extract.on("finish", function () {
-    expect().pass();
+    assert.ok(true);
   });
 
   extract.end(fs.readFileSync(fixtures.BASE_256_SIZE));
@@ -554,7 +555,7 @@ test("latin-1", function () {
   let noEntries = false;
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "En français, s'il vous plaît?.txt",
       mode: 0o644,
       uid: 0,
@@ -573,14 +574,14 @@ test("latin-1", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("Hello, world!\n");
+        assert.strictEqual(data.toString(), "Hello, world!\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.LATIN1_TAR));
@@ -594,11 +595,11 @@ test("incomplete", function () {
   });
 
   extract.on("error", function (err) {
-    expect(err.message).toBe("Unexpected end of data");
+    assert.strictEqual(err.message, "Unexpected end of data");
   });
 
   extract.on("finish", function () {
-    expect.unreachable("should not finish");
+    assert.fail("should not finish");
   });
 
   extract.end(fs.readFileSync(fixtures.INCOMPLETE_TAR));
@@ -611,7 +612,7 @@ test("gnu", function () {
   let noEntries = false;
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "test.txt",
       mode: 0o644,
       uid: 12345,
@@ -630,14 +631,14 @@ test("gnu", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("Hello, world!\n");
+        assert.strictEqual(data.toString(), "Hello, world!\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.GNU_TAR));
@@ -653,7 +654,7 @@ test("gnu-incremental", function () {
   let noEntries = false;
 
   extract.on("entry", function (header, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "test.txt",
       mode: 0o644,
       uid: 12345,
@@ -672,14 +673,14 @@ test("gnu-incremental", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("Hello, world!\n");
+        assert.strictEqual(data.toString(), "Hello, world!\n");
         cb();
       }),
     );
   });
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.GNU_INCREMENTAL_TAR));
@@ -691,7 +692,7 @@ test("v7 unsupported", function () {
   const extract = tar.extract();
 
   extract.on("error", function (err) {
-    expect(!!err).toBeTrue();
+    assert.ok(err);
     extract.destroy();
   });
 
@@ -702,7 +703,7 @@ test("unknown format doesn't extract by default", function () {
   const extract = tar.extract();
 
   extract.on("error", function (err) {
-    expect(!!err).toBeTrue();
+    assert.ok(err);
     extract.destroy();
   });
 
@@ -716,13 +717,13 @@ test("unknown format attempts to extract if allowed", function () {
   extract.once("entry", onfile1);
 
   extract.on("finish", function () {
-    expect(noEntries).toBeTrue();
+    assert.ok(noEntries);
   });
 
   extract.end(fs.readFileSync(fixtures.UNKNOWN_FORMAT));
 
   function onfile1(header: unknown, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "file-1.txt",
       mode: 0o644,
       uid: 501,
@@ -741,14 +742,14 @@ test("unknown format attempts to extract if allowed", function () {
     extract.on("entry", onfile2);
     stream.pipe(
       concat(function (data) {
-        expect(data.toString()).toBe("i am file-1\n");
+        assert.strictEqual(data.toString(), "i am file-1\n");
         cb();
       }),
     );
   }
 
   function onfile2(header: unknown, stream, cb) {
-    expect(header).toEqual({
+    assert.deepStrictEqual(header, {
       name: "file-2.txt",
       mode: 0o644,
       uid: 501,
@@ -767,7 +768,7 @@ test("unknown format attempts to extract if allowed", function () {
     stream.pipe(
       concat(function (data) {
         noEntries = true;
-        expect(data.toString()).toBe("i am file-2\n");
+        assert.strictEqual(data.toString(), "i am file-2\n");
         cb();
       }),
     );
@@ -783,7 +784,7 @@ test("extract streams are async iterators", async function () {
   const expected = ["file-1.txt", "file-2.txt"];
 
   for await (const entry of extract) {
-    expect<string | undefined>(entry.header.name).toBe(expected.shift());
+    assert.strictEqual(entry.header.name, expected.shift());
     entry.resume();
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
@@ -804,13 +805,13 @@ test("async iterator - early break calls destroy", async function () {
   // Iterate but break after the first entry
   // This triggers the iterator's .return() -> internal destroy()
   for await (const entry of extract) {
-    expect(entry.header.name).toBe("file-1.txt");
+    assert.strictEqual(entry.header.name, "file-1.txt");
     entry.resume();
     break;
   }
 
-  expect(extract.destroyed).toBeTrue();
-  expect(closed).toBeTrue();
+  assert.ok(extract.destroyed);
+  assert.ok(closed);
 });
 
 test("async iterator - explicit throw calls destroy", async function () {
@@ -826,10 +827,10 @@ test("async iterator - explicit throw calls destroy", async function () {
       throw error; // This triggers the iterator's .throw() or .return()
     }
   } catch (err) {
-    expect(err).toBe(error);
+    assert.strictEqual(err, error);
   }
 
-  expect(extract.destroyed).toBeTrue();
+  assert.ok(extract.destroyed);
 });
 
 function clamp(index: number, len: number) {

--- a/packages/tar-stream/tests/huge.test.ts
+++ b/packages/tar-stream/tests/huge.test.ts
@@ -1,5 +1,6 @@
-import { test, expect } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { test } from "node:test";
 import * as zlib from "node:zlib";
 
 import * as tar from "../src/index";
@@ -8,9 +9,9 @@ import * as fixtures from "./fixtures";
 
 const win32 = process.platform === "win32";
 
-test.skipIf(win32)(
-  "huge",
-  (done) => {
+const it = win32 ? test.skip : test;
+it("huge", { timeout: 6e4 * 3 }, () => {
+  return new Promise<void>((resolve) => {
     const extract = tar.extract();
     let noEntries = false;
     const hugeFileSize = 8804630528; // ~8.2GB
@@ -25,7 +26,7 @@ test.skipIf(win32)(
 
     // Make sure we read the correct pax size entry for a file larger than 8GB.
     extract.on("entry", function (header, stream, callback) {
-      expect(header).toEqual({
+      assert.deepStrictEqual(header, {
         devmajor: 0,
         devminor: 0,
         gid: 20,
@@ -55,14 +56,13 @@ test.skipIf(win32)(
     });
 
     extract.on("finish", function () {
-      expect(noEntries).toBeTrue();
-      expect(dataLength).toBe(hugeFileSize);
-      done();
+      assert.ok(noEntries);
+      assert.strictEqual(dataLength, hugeFileSize);
+      resolve();
     });
 
     const gunzip = zlib.createGunzip();
     const reader = fs.createReadStream(fixtures.HUGE);
     reader.pipe(gunzip).pipe(extract);
-  },
-  { timeout: 6e4 * 3 }, // 3 minutes
-);
+  });
+});

--- a/packages/tar-stream/tests/pack.test.ts
+++ b/packages/tar-stream/tests/pack.test.ts
@@ -1,5 +1,6 @@
-import { test, expect } from "bun:test";
+import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { test } from "node:test";
 
 import concat from "es-concat-stream";
 
@@ -27,8 +28,8 @@ test("one-file", function () {
 
   pack.pipe(
     concat(function (data) {
-      expect(data.length & 511).toBe(0);
-      expect(data).toEqual(fs.readFileSync(fixtures.ONE_FILE_TAR));
+      assert.strictEqual(data.length & 511, 0);
+      assert.deepStrictEqual(data, fs.readFileSync(fixtures.ONE_FILE_TAR));
     }),
   );
 });
@@ -66,8 +67,8 @@ test("multi-file", function () {
 
   pack.pipe(
     concat(function (data) {
-      expect(data.length & 511).toBe(0);
-      expect(data).toEqual(fs.readFileSync(fixtures.MULTI_FILE_TAR));
+      assert.strictEqual(data.length & 511, 0);
+      assert.deepStrictEqual(data, fs.readFileSync(fixtures.MULTI_FILE_TAR));
     }),
   );
 });
@@ -93,8 +94,8 @@ test("pax", function () {
 
   pack.pipe(
     concat(function (data) {
-      expect(data.length & 511).toBe(0);
-      expect(data).toEqual(fs.readFileSync(fixtures.PAX_TAR));
+      assert.strictEqual(data.length & 511, 0);
+      assert.deepStrictEqual(data, fs.readFileSync(fixtures.PAX_TAR));
     }),
   );
 });
@@ -130,37 +131,39 @@ test("types", function () {
 
   pack.pipe(
     concat(function (data) {
-      expect(data.length & 511).toBe(0);
-      expect(data).toEqual(fs.readFileSync(fixtures.TYPES_TAR));
+      assert.strictEqual(data.length & 511, 0);
+      assert.deepStrictEqual(data, fs.readFileSync(fixtures.TYPES_TAR));
     }),
   );
 });
 
-test("empty directory body is valid", function (done) {
-  const pack = tar.pack();
+test("empty directory body is valid", () => {
+  return new Promise<void>((resolve) => {
+    const pack = tar.pack();
 
-  pack.entry(
-    {
-      name: "directory",
-      mtime: new Date(1387580181000),
-      type: "directory",
-      mode: 0o755,
-      uname: "maf",
-      gname: "staff",
-      uid: 501,
-      gid: 20,
-    },
-    "",
-  );
+    pack.entry(
+      {
+        name: "directory",
+        mtime: new Date(1387580181000),
+        type: "directory",
+        mode: 0o755,
+        uname: "maf",
+        gname: "staff",
+        uid: 501,
+        gid: 20,
+      },
+      "",
+    );
 
-  pack.finalize();
+    pack.finalize();
 
-  pack.resume();
+    pack.resume();
 
-  pack.on("error", () => expect().fail("should not throw"));
-  pack.on("close", () => {
-    expect().pass("closed");
-    done();
+    pack.on("error", () => assert.fail("should not throw"));
+    pack.on("close", () => {
+      assert.ok(true);
+      resolve();
+    });
   });
 });
 
@@ -185,8 +188,8 @@ test("long-name", function () {
 
   pack.pipe(
     concat(function (data) {
-      expect(data.length & 511).toBe(0);
-      expect(data).toEqual(fs.readFileSync(fixtures.LONG_NAME_TAR));
+      assert.strictEqual(data.length & 511, 0);
+      assert.deepStrictEqual(data, fs.readFileSync(fixtures.LONG_NAME_TAR));
     }),
   );
 });
@@ -211,8 +214,8 @@ test("large-uid-gid", function () {
 
   pack.pipe(
     concat(function (data) {
-      expect(data.length & 511).toBe(0);
-      expect(data).toEqual(fs.readFileSync(fixtures.LARGE_UID_GID));
+      assert.strictEqual(data.length & 511, 0);
+      assert.deepStrictEqual(data, fs.readFileSync(fixtures.LARGE_UID_GID));
     }),
   );
 });
@@ -238,56 +241,58 @@ test("unicode", function () {
 
   pack.pipe(
     concat(function (data) {
-      expect(data.length & 511).toBe(0);
-      expect(data).toEqual(fs.readFileSync(fixtures.UNICODE_TAR));
+      assert.strictEqual(data.length & 511, 0);
+      assert.deepStrictEqual(data, fs.readFileSync(fixtures.UNICODE_TAR));
     }),
   );
 });
 
-test("backpressure", function (done) {
-  const slowStream = new Writable({
-    highWaterMark: 1,
+test("backpressure", () => {
+  return new Promise<void>((resolve) => {
+    const slowStream = new Writable({
+      highWaterMark: 1,
 
-    write(data, cb) {
-      setImmediate(cb);
-    },
+      write(data, cb) {
+        setImmediate(cb);
+      },
+    });
+
+    slowStream.on("finish", () => {
+      assert.ok(true);
+      resolve();
+    });
+
+    const pack = tar.pack();
+
+    let later = false;
+
+    setImmediate(() => {
+      later = true;
+    });
+
+    pack.on("end", () => assert.ok(later)).pipe(slowStream);
+
+    let i = 0;
+    const next = () => {
+      if (++i < 25) {
+        const header = {
+          name: `file${i}.txt`,
+          mtime: new Date(1387580181000),
+          mode: 0o644,
+          uname: "maf",
+          gname: "staff",
+          uid: 501,
+          gid: 20,
+        };
+
+        const buffer = Buffer.alloc(1024);
+
+        pack.entry(header, buffer, next);
+      } else {
+        pack.finalize();
+      }
+    };
+
+    next();
   });
-
-  slowStream.on("finish", () => {
-    expect().pass();
-    done();
-  });
-
-  const pack = tar.pack();
-
-  let later = false;
-
-  setImmediate(() => {
-    later = true;
-  });
-
-  pack.on("end", () => expect(later).toBeTrue()).pipe(slowStream);
-
-  let i = 0;
-  const next = () => {
-    if (++i < 25) {
-      const header = {
-        name: `file${i}.txt`,
-        mtime: new Date(1387580181000),
-        mode: 0o644,
-        uname: "maf",
-        gname: "staff",
-        uid: 501,
-        gid: 20,
-      };
-
-      const buffer = Buffer.alloc(1024);
-
-      pack.entry(header, buffer, next);
-    } else {
-      pack.finalize();
-    }
-  };
-
-  next();
 });

--- a/packages/zip-stream/tests/compress-commons/general-purpose-bit.test.ts
+++ b/packages/zip-stream/tests/compress-commons/general-purpose-bit.test.ts
@@ -1,4 +1,5 @@
-import { expect, it, beforeEach, describe } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 import { GeneralPurposeBit } from "../../src/archivers/general-purpose-bit";
 
@@ -13,7 +14,7 @@ describe("GeneralPurposeBit", () => {
     it("should return a Buffer", () => {
       gpb.useDataDescriptor(true);
       const encoded = gpb.encode();
-      expect(Buffer.isBuffer(encoded)).toBe(true);
+      assert.ok(Buffer.isBuffer(encoded));
     });
   });
 });

--- a/packages/zip-stream/tests/compress-commons/zip-archive-entry.test.ts
+++ b/packages/zip-stream/tests/compress-commons/zip-archive-entry.test.ts
@@ -1,4 +1,5 @@
-import { expect, it, beforeEach, describe } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
 
 import { GeneralPurposeBit } from "../../src/archivers/general-purpose-bit";
 import * as UnixStat from "../../src/archivers/unix-stat";
@@ -16,28 +17,28 @@ describe("ZipArchiveEntry", () => {
   describe("#getComment", () => {
     it("should return the comment", () => {
       entry.setComment("file comment");
-      expect(entry.getComment()).toBe("file comment");
+      assert.strictEqual(entry.getComment(), "file comment");
     });
   });
 
   describe("#getCompressedSize", () => {
     it("should return the compressed size", () => {
       entry.csize = 10;
-      expect(entry.getCompressedSize()).toBe(10);
+      assert.strictEqual(entry.getCompressedSize(), 10);
     });
   });
 
   describe("#getCrc", () => {
     it("should return the CRC32", () => {
       entry.crc = 585446183;
-      expect(entry.getCrc()).toBe(585446183);
+      assert.strictEqual(entry.getCrc(), 585446183);
     });
   });
 
   describe("#getExternalAttributes", () => {
     it("should return the external attributes", () => {
       entry.exattr = 2180972576;
-      expect(entry.getExternalAttributes()).toBe(2180972576);
+      assert.strictEqual(entry.getExternalAttributes(), 2180972576);
     });
   });
 
@@ -46,56 +47,56 @@ describe("ZipArchiveEntry", () => {
       const gpb = new GeneralPurposeBit();
       gpb.useDataDescriptor(true);
       entry.gpb = gpb;
-      expect(entry.getGeneralPurposeBit()).toBe(gpb);
+      assert.strictEqual(entry.getGeneralPurposeBit(), gpb);
     });
   });
 
   describe("#getInternalAttributes", () => {
     it("should return the internal attributes", () => {
       entry.inattr = 2180972576;
-      expect(entry.getInternalAttributes()).toBe(2180972576);
+      assert.strictEqual(entry.getInternalAttributes(), 2180972576);
     });
   });
 
   describe("#getMethod", () => {
     it("should return the compression method", () => {
       entry.method = 0;
-      expect(entry.getMethod()).toBe(0);
+      assert.strictEqual(entry.getMethod(), 0);
     });
   });
 
   describe("#getName", () => {
     it("should return the name", () => {
       entry.name = "file.txt";
-      expect(entry.getName()).toBe("file.txt");
+      assert.strictEqual(entry.getName(), "file.txt");
     });
   });
 
   describe("#getPlatform", () => {
     it("should return the platform", () => {
       entry.platform = 3;
-      expect(entry.getPlatform()).toBe(3);
+      assert.strictEqual(entry.getPlatform(), 3);
     });
   });
 
   describe("#getSize", () => {
     it("should return the size", () => {
       entry.size = 25;
-      expect(entry.getSize()).toBe(25);
+      assert.strictEqual(entry.getSize(), 25);
     });
   });
 
   describe("#getTime", () => {
     it("should return a Date object", () => {
       entry.time = 1109607251;
-      expect(entry.getTime()).toBeInstanceOf(Date);
+      assert.ok(entry.getTime() instanceof Date);
     });
   });
 
   describe("#getTimeDos", () => {
     it("should return a number", () => {
       entry.time = 1109607251;
-      expect(typeof entry.getTimeDos()).toBe("number");
+      assert.strictEqual(typeof entry.getTimeDos(), "number");
     });
   });
 
@@ -104,49 +105,49 @@ describe("ZipArchiveEntry", () => {
       entry.mode = 511; // 0777
       entry.exattr = 2180972576;
       entry.platform = 3;
-      expect(entry.getUnixMode()).toBe(33279); // 0100777
+      assert.strictEqual(entry.getUnixMode(), 33279); // 0100777
     });
 
     it("should set proper external attributes for an unix directory", () => {
       entry = new ZipArchiveEntry("directory/");
       entry.setUnixMode(511); // 0777
-      expect(entry.getPlatform()).toBe(3);
-      expect(entry.isDirectory()).toBe(true);
+      assert.strictEqual(entry.getPlatform(), 3);
+      assert.ok(entry.isDirectory());
       const exattr = entry.getExternalAttributes() >> 16;
-      expect(exattr & 16384).toBe(16384); // 040000
+      assert.strictEqual(exattr & 16384, 16384); // 040000
     });
   });
 
   describe("#setComment", () => {
     it("should set internal variable", () => {
       entry.setComment("file comment");
-      expect(entry).toHaveProperty("comment", "file comment");
+      assert.strictEqual(entry.comment, "file comment");
     });
 
     it("should set utf8 bit when receiving strings byte count != string length", () => {
       entry.setComment("ÀÁÂÃÄÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝàáâãäçèéêëìíîïñòóôõöùúûüýÿ");
-      expect(entry.getGeneralPurposeBit().usesUTF8ForNames()).toBe(true);
+      assert.ok(entry.getGeneralPurposeBit().usesUTF8ForNames());
     });
   });
 
   describe("#setCompressedSize", () => {
     it("should set internal variable", () => {
       entry.setCompressedSize(10);
-      expect(entry).toHaveProperty("csize", 10);
+      assert.strictEqual(entry.csize, 10);
     });
   });
 
   describe("#setCrc", () => {
     it("should set internal variable", () => {
       entry.setCrc(585446183);
-      expect(entry).toHaveProperty("crc", 585446183);
+      assert.strictEqual(entry.crc, 585446183);
     });
   });
 
   describe("#setExternalAttributes", () => {
     it("should set internal variable", () => {
       entry.setExternalAttributes(2180972576);
-      expect(entry).toHaveProperty("exattr", 2180972576);
+      assert.strictEqual(entry.exattr, 2180972576);
     });
   });
 
@@ -155,114 +156,114 @@ describe("ZipArchiveEntry", () => {
       const gpb = new GeneralPurposeBit();
       gpb.useDataDescriptor(true);
       entry.setGeneralPurposeBit(gpb);
-      expect(entry).toHaveProperty("gpb", gpb);
+      assert.strictEqual(entry.gpb, gpb);
     });
   });
 
   describe("#setInternalAttributes", () => {
     it("should set internal variable", () => {
       entry.setInternalAttributes(2180972576);
-      expect(entry).toHaveProperty("inattr", 2180972576);
+      assert.strictEqual(entry.inattr, 2180972576);
     });
   });
 
   describe("#setMethod", () => {
     it("should set internal variable", () => {
       entry.setMethod(8);
-      expect(entry).toHaveProperty("method", 8);
+      assert.strictEqual(entry.method, 8);
     });
   });
 
   describe("#setName", () => {
     it("should set internal variable", () => {
       entry.setName("file.txt");
-      expect(entry).toHaveProperty("name", "file.txt");
+      assert.strictEqual(entry.name, "file.txt");
     });
 
     it("should allow setting prefix of / at the beginning of path", () => {
       entry.setName("file.txt", true);
-      expect(entry).toHaveProperty("name", "/file.txt");
+      assert.strictEqual(entry.name, "/file.txt");
     });
 
     it("should allow ./ at the beginning of path", () => {
       entry.setName("./file.txt");
-      expect(entry).toHaveProperty("name", "./file.txt");
+      assert.strictEqual(entry.name, "./file.txt");
     });
 
     it("should clean windows style paths", () => {
       entry.setName("\\windows\\file.txt");
-      expect(entry).toHaveProperty("name", "windows/file.txt");
+      assert.strictEqual(entry.name, "windows/file.txt");
 
       entry.setName("c:\\this\\path\\file.txt");
-      expect(entry).toHaveProperty("name", "this/path/file.txt");
+      assert.strictEqual(entry.name, "this/path/file.txt");
 
       entry.setName("\\\\server\\share\\");
-      expect(entry).toHaveProperty("name", "server/share/");
+      assert.strictEqual(entry.name, "server/share/");
     });
 
     it("should clean multiple forward slashes at beginning of path", () => {
       entry.setName("//forward/file.txt");
-      expect(entry).toHaveProperty("name", "forward/file.txt");
+      assert.strictEqual(entry.name, "forward/file.txt");
     });
 
     it("should set utf8 bit when receiving strings byte count != string length", () => {
       entry.setName("ÀÁÂÃÄÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝàáâãäçèéêëìíîïñòóôõöùúûüýÿ.txt");
-      expect(entry.getGeneralPurposeBit().usesUTF8ForNames()).toBe(true);
+      assert.ok(entry.getGeneralPurposeBit().usesUTF8ForNames());
     });
   });
 
   describe("#setPlatform", () => {
     it("should set internal variable", () => {
       entry.setPlatform(3);
-      expect(entry).toHaveProperty("platform", 3);
+      assert.strictEqual(entry.platform, 3);
     });
   });
 
   describe("#setSize", () => {
     it("should set internal variable", () => {
       entry.setSize(15);
-      expect(entry).toHaveProperty("size", 15);
+      assert.strictEqual(entry.size, 15);
     });
   });
 
   describe("#setTime", () => {
     it("should set internal variable", () => {
       entry.setTime(testDate);
-      expect(entry).toHaveProperty("time", 1109619539);
+      assert.strictEqual(entry.time, 1109619539);
     });
   });
 
   describe("#setUnixMode", () => {
     it("should set internal variables", () => {
       entry.setUnixMode(511);
-      expect(entry).toHaveProperty("exattr", 2180972576);
-      expect(entry).toHaveProperty("mode", 511); // 0777
-      expect(entry.getUnixMode()).toBe(33279); // 0100777
+      assert.strictEqual(entry.exattr, 2180972576);
+      assert.strictEqual(entry.mode, 511); // 0777
+      assert.strictEqual(entry.getUnixMode(), 33279); // 0100777
     });
 
     it("should also preserve filetype information", () => {
       entry.setUnixMode(41453);
-      expect(entry).toHaveProperty("exattr", 2716663840);
-      expect(entry).toHaveProperty("mode", 493); // 0755
-      expect(entry.getUnixMode()).toBe(41453); // 0120755
+      assert.strictEqual(entry.exattr, 2716663840);
+      assert.strictEqual(entry.mode, 493); // 0755
+      assert.strictEqual(entry.getUnixMode(), 41453); // 0120755
     });
   });
 
   describe("#isDirectory", () => {
     it("should return a boolean based on name of entry", () => {
-      expect(entry.isDirectory()).toBe(false);
+      assert.ok(!entry.isDirectory());
       entry.setName("some/directory/");
-      expect(entry.isDirectory()).toBe(true);
+      assert.ok(entry.isDirectory());
     });
   });
 
   describe("#isUnixSymlink", () => {
     it("should return a boolean if the entry is a symlink", () => {
       entry.setUnixMode(UnixStat.LINK_FLAG);
-      expect(entry.isUnixSymlink()).toBe(true);
+      assert.ok(entry.isUnixSymlink());
 
       entry.setUnixMode(UnixStat.LINK_FLAG | UnixStat.DIR_FLAG);
-      expect(entry.isUnixSymlink()).toBe(false);
+      assert.ok(!entry.isUnixSymlink());
     });
   });
 });

--- a/packages/zip-stream/tests/compress-commons/zip-archive-output-stream.test.ts
+++ b/packages/zip-stream/tests/compress-commons/zip-archive-output-stream.test.ts
@@ -1,7 +1,8 @@
-import { expect, it, beforeAll, describe } from "bun:test";
+import assert from "node:assert/strict";
 import { createReadStream, mkdirSync } from "node:fs";
 import { Transform } from "node:stream";
 import { Readable } from "node:stream";
+import { describe, it, before } from "node:test";
 
 import {
   ZipArchiveEntry,
@@ -11,7 +12,7 @@ import { WriteHashStream, binaryBuffer } from "./helpers/index";
 
 const testBuffer = binaryBuffer(1024 * 16);
 
-beforeAll(() => {
+before(() => {
   mkdirSync("tmp", { recursive: true });
 });
 
@@ -75,8 +76,8 @@ describe("ZipArchiveOutputStream", () => {
 
       const promise = new Promise((resolve) => {
         testStream.on("close", () => {
-          expect(callbackError?.message).toBe("something went wrong");
-          expect(callbackCalls).toBe(1);
+          assert.strictEqual(callbackError?.message, "something went wrong");
+          assert.strictEqual(callbackCalls, 1);
           resolve(undefined);
         });
       });
@@ -92,7 +93,7 @@ describe("ZipArchiveOutputStream", () => {
       archive.finish();
 
       // Give it a tick to make sure entry is being processed
-      await Bun.sleep(1);
+      await new Promise((r) => setTimeout(r, 1));
 
       file.emit("error", new Error("something went wrong"));
 

--- a/packages/zip-stream/tests/pack.test.ts
+++ b/packages/zip-stream/tests/pack.test.ts
@@ -1,6 +1,6 @@
-import { describe, beforeAll, it } from "bun:test";
 import { createReadStream, createWriteStream, mkdirSync } from "node:fs";
 import { Readable } from "node:stream";
+import { describe, it, before } from "node:test";
 
 import { ZipStream as Packer } from "../src/index.js";
 import { binaryBuffer, fileBuffer } from "./helpers/index.js";
@@ -12,76 +12,88 @@ const testDateOverflow = new Date("Jan 1 2044 00:00:00 GMT");
 const testDateUnderflow = new Date("Dec 30 1979 23:59:58 GMT");
 
 describe("pack", () => {
-  beforeAll(() => {
+  before(() => {
     mkdirSync("tmp", { recursive: true });
   });
 
   describe("#entry", () => {
-    it("should append Buffer sources", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/buffer.zip");
-      testStream.on("close", () => {
-        done();
+    it("should append Buffer sources", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/buffer.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(testBuffer, { name: "buffer.txt", date: testDate });
+        archive.finalize();
       });
-      archive.pipe(testStream);
-      archive.entry(testBuffer, { name: "buffer.txt", date: testDate });
-      archive.finalize();
     });
 
-    it("should append Stream sources", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/stream.zip");
-      testStream.on("close", () => {
-        done();
+    it("should append Stream sources", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/stream.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(createReadStream("tests/fixtures/test.txt"), {
+          name: "stream.txt",
+          date: testDate,
+        });
+        archive.finalize();
       });
-      archive.pipe(testStream);
-      archive.entry(createReadStream("tests/fixtures/test.txt"), {
-        name: "stream.txt",
-        date: testDate,
-      });
-      archive.finalize();
     });
 
-    it("should append Stream-like sources", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/stream-like.zip");
-      testStream.on("close", () => {
-        done();
+    it("should append Stream-like sources", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/stream-like.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(Readable.from(["test"]), {
+          name: "stream-like.txt",
+          date: testDate,
+        });
+        archive.finalize();
       });
-      archive.pipe(testStream);
-      archive.entry(Readable.from(["test"]), {
-        name: "stream-like.txt",
-        date: testDate,
-      });
-      archive.finalize();
     });
 
-    it("should append multiple sources", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/multiple.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
+    it("should append multiple sources", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/multiple.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
 
-      archive.entry("string", { name: "string.txt", date: testDate }, (err) => {
-        if (err) throw err;
         archive.entry(
-          testBuffer,
-          { name: "buffer.txt", date: testDate2 },
+          "string",
+          { name: "string.txt", date: testDate },
           (err) => {
             if (err) throw err;
             archive.entry(
-              createReadStream("tests/fixtures/test.txt"),
-              { name: "stream.txt", date: testDate2 },
+              testBuffer,
+              { name: "buffer.txt", date: testDate2 },
               (err) => {
                 if (err) throw err;
                 archive.entry(
                   createReadStream("tests/fixtures/test.txt"),
-                  { name: "stream-store.txt", date: testDate, store: true },
+                  { name: "stream.txt", date: testDate2 },
                   (err) => {
                     if (err) throw err;
-                    archive.finalize();
+                    archive.entry(
+                      createReadStream("tests/fixtures/test.txt"),
+                      { name: "stream-store.txt", date: testDate, store: true },
+                      (err) => {
+                        if (err) throw err;
+                        archive.finalize();
+                      },
+                    );
                   },
                 );
               },
@@ -91,271 +103,98 @@ describe("pack", () => {
       });
     });
 
-    it("should support STORE for Buffer sources", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/buffer-store.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.entry(testBuffer, {
-        name: "buffer.txt",
-        date: testDate,
-        store: true,
-      });
-      archive.finalize();
-    });
-
-    it("should support STORE for Stream sources", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/stream-store.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.entry(createReadStream("tests/fixtures/test.txt"), {
-        name: "stream.txt",
-        date: testDate,
-        store: true,
-      });
-      archive.finalize();
-    });
-
-    it("should support archive and file comments", (done) => {
-      const archive = new Packer({
-        comment: "this is a zip comment",
-      });
-      const testStream = createWriteStream("tmp/comments.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.entry(testBuffer, {
-        name: "buffer.txt",
-        date: testDate,
-        comment: "this is a file comment",
-      });
-      archive.finalize();
-    });
-
-    it("should STORE files when compression level is zero", (done) => {
-      const archive = new Packer({
-        level: 0,
-      });
-      const testStream = createWriteStream("tmp/store-level0.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.entry(testBuffer, { name: "buffer.txt", date: testDate });
-      archive.finalize();
-    });
-
-    it("should properly handle utf8 encoded characters in file names and comments", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/accentedchars-filenames.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-
-      archive.entry(
-        testBuffer,
-        {
-          name: "àáâãäçèéêëìíîïñòóôõöùúûüýÿ.txt",
+    it("should support STORE for Buffer sources", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/buffer-store.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(testBuffer, {
+          name: "buffer.txt",
           date: testDate,
-          comment: "àáâãäçèéêëìíîïñòóôõöùúûüýÿ",
-        },
-        (err) => {
-          if (err) throw err;
-          archive.entry(
-            testBuffer,
-            {
-              name: "ÀÁÂÃÄÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝ.txt",
-              date: testDate2,
-              comment: "ÀÁÂÃÄÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝ",
-            },
-            (err) => {
-              if (err) throw err;
-              archive.finalize();
-            },
-          );
-        },
-      );
+          store: true,
+        });
+        archive.finalize();
+      });
     });
 
-    it("should append zero length sources", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/zerolength.zip");
-      testStream.on("close", () => {
-        done();
+    it("should support STORE for Stream sources", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/stream-store.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(createReadStream("tests/fixtures/test.txt"), {
+          name: "stream.txt",
+          date: testDate,
+          store: true,
+        });
+        archive.finalize();
       });
-      archive.pipe(testStream);
+    });
 
-      archive.entry("", { name: "string.txt", date: testDate }, (err) => {
-        if (err) throw err;
+    it("should support archive and file comments", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer({
+          comment: "this is a zip comment",
+        });
+        const testStream = createWriteStream("tmp/comments.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(testBuffer, {
+          name: "buffer.txt",
+          date: testDate,
+          comment: "this is a file comment",
+        });
+        archive.finalize();
+      });
+    });
+
+    it("should STORE files when compression level is zero", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer({
+          level: 0,
+        });
+        const testStream = createWriteStream("tmp/store-level0.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(testBuffer, { name: "buffer.txt", date: testDate });
+        archive.finalize();
+      });
+    });
+
+    it("should properly handle utf8 encoded characters in file names and comments", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/accentedchars-filenames.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+
         archive.entry(
-          Buffer.alloc(0),
-          { name: "buffer.txt", date: testDate },
-          (err) => {
-            if (err) throw err;
-            archive.entry(
-              createReadStream("tests/fixtures/empty.txt"),
-              { name: "stream.txt", date: testDate },
-              (err) => {
-                if (err) throw err;
-                archive.finalize();
-              },
-            );
-          },
-        );
-      });
-    });
-
-    it("should support setting file mode (permissions)", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/filemode.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.entry(testBuffer, {
-        name: "buffer.txt",
-        date: testDate,
-        mode: 420,
-      }); // 0644
-      archive.finalize();
-    });
-
-    it("should support creating an empty zip", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/empty.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.finalize();
-    });
-
-    it("should support compressing images for Buffer sources", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/buffer-image.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.entry(fileBuffer("tests/fixtures/image.png"), {
-        name: "image.png",
-        date: testDate,
-      });
-      archive.finalize();
-    });
-
-    it("should support compressing images for Stream sources", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/stream-image.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.entry(createReadStream("tests/fixtures/image.png"), {
-        name: "image.png",
-        date: testDate,
-      });
-      archive.finalize();
-    });
-
-    it("should prevent UInt32 under/overflow of dates", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/date-boundaries.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-
-      archive.entry(
-        testBuffer,
-        { name: "date-underflow.txt", date: testDateUnderflow },
-        (err) => {
-          if (err) throw err;
-          archive.entry(
-            testBuffer,
-            { name: "date-overflow.txt", date: testDateOverflow },
-            (err) => {
-              if (err) throw err;
-              archive.finalize();
-            },
-          );
-        },
-      );
-    });
-
-    it("should handle data that exceeds its internal buffer size", (done) => {
-      const archive = new Packer({
-        highWaterMark: 1024 * 4,
-      });
-      const testStream = createWriteStream("tmp/buffer-overflow.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-
-      archive.entry(
-        binaryBuffer(1024 * 512),
-        { name: "buffer-overflow.txt", date: testDate },
-        (err) => {
-          if (err) throw err;
-          archive.entry(
-            binaryBuffer(1024 * 1024),
-            { name: "buffer-overflow-store.txt", date: testDate, store: true },
-            (err) => {
-              if (err) throw err;
-              archive.finalize();
-            },
-          );
-        },
-      );
-    });
-
-    it("should support directory entries", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/type-directory.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.entry(null, { name: "directory/", date: testDate });
-      archive.finalize();
-    });
-
-    it("should support symlink entries", (done) => {
-      const archive = new Packer();
-      const testStream = createWriteStream("tmp/type-symlink.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-
-      archive.entry("some text", { name: "file", date: testDate }, (err) => {
-        if (err) throw err;
-        archive.entry(
-          null,
+          testBuffer,
           {
-            type: "symlink",
-            name: "file-link",
-            linkname: "file",
+            name: "àáâãäçèéêëìíîïñòóôõöùúûüýÿ.txt",
             date: testDate,
+            comment: "àáâãäçèéêëìíîïñòóôõöùúûüýÿ",
           },
           (err) => {
             if (err) throw err;
             archive.entry(
-              null,
+              testBuffer,
               {
-                type: "symlink",
-                name: "file-link-2",
-                linkname: "file",
-                date: testDate,
-                mode: 420,
+                name: "ÀÁÂÃÄÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝ.txt",
+                date: testDate2,
+                comment: "ÀÁÂÃÄÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝ",
               },
               (err) => {
                 if (err) throw err;
@@ -367,30 +206,237 @@ describe("pack", () => {
       });
     });
 
-    it("should support appending forward slash to entry names", (done) => {
-      const archive = new Packer({
-        namePrependSlash: true,
-      });
-      const testStream = createWriteStream("tmp/name-prepend-slash.zip");
-      testStream.on("close", () => {
-        done();
-      });
-      archive.pipe(testStream);
-      archive.entry(
-        "some text",
-        { name: "file", namePrependSlash: false, date: testDate },
-        (err) => {
+    it("should append zero length sources", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/zerolength.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+
+        archive.entry("", { name: "string.txt", date: testDate }, (err) => {
           if (err) throw err;
           archive.entry(
-            "more text",
-            { type: "file", name: "file-with-prefix", date: testDate },
+            Buffer.alloc(0),
+            { name: "buffer.txt", date: testDate },
             (err) => {
               if (err) throw err;
-              archive.finalize();
+              archive.entry(
+                createReadStream("tests/fixtures/empty.txt"),
+                { name: "stream.txt", date: testDate },
+                (err) => {
+                  if (err) throw err;
+                  archive.finalize();
+                },
+              );
             },
           );
-        },
-      );
+        });
+      });
+    });
+
+    it("should support setting file mode (permissions)", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/filemode.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(testBuffer, {
+          name: "buffer.txt",
+          date: testDate,
+          mode: 420,
+        }); // 0644
+        archive.finalize();
+      });
+    });
+
+    it("should support creating an empty zip", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/empty.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.finalize();
+      });
+    });
+
+    it("should support compressing images for Buffer sources", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/buffer-image.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(fileBuffer("tests/fixtures/image.png"), {
+          name: "image.png",
+          date: testDate,
+        });
+        archive.finalize();
+      });
+    });
+
+    it("should support compressing images for Stream sources", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/stream-image.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(createReadStream("tests/fixtures/image.png"), {
+          name: "image.png",
+          date: testDate,
+        });
+        archive.finalize();
+      });
+    });
+
+    it("should prevent UInt32 under/overflow of dates", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/date-boundaries.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+
+        archive.entry(
+          testBuffer,
+          { name: "date-underflow.txt", date: testDateUnderflow },
+          (err) => {
+            if (err) throw err;
+            archive.entry(
+              testBuffer,
+              { name: "date-overflow.txt", date: testDateOverflow },
+              (err) => {
+                if (err) throw err;
+                archive.finalize();
+              },
+            );
+          },
+        );
+      });
+    });
+
+    it("should handle data that exceeds its internal buffer size", async () => {
+      await new Promise<void>((resolve) => {
+        const archive = new Packer({
+          highWaterMark: 1024 * 4,
+        });
+        const testStream = createWriteStream("tmp/buffer-overflow.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+
+        archive.entry(
+          binaryBuffer(1024 * 512),
+          { name: "buffer-overflow.txt", date: testDate },
+          (err) => {
+            if (err) throw err;
+            archive.entry(
+              binaryBuffer(1024 * 1024),
+              {
+                name: "buffer-overflow-store.txt",
+                date: testDate,
+                store: true,
+              },
+              (err) => {
+                if (err) throw err;
+                archive.finalize();
+              },
+            );
+          },
+        );
+      });
+    });
+
+    it("should support directory entries", () => {
+      return new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/type-directory.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(null, { name: "directory/", date: testDate });
+        archive.finalize();
+      });
+    });
+
+    it("should support symlink entries", async () => {
+      await new Promise<void>((resolve) => {
+        const archive = new Packer();
+        const testStream = createWriteStream("tmp/type-symlink.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+
+        archive.entry("some text", { name: "file", date: testDate }, (err) => {
+          if (err) throw err;
+          archive.entry(
+            null,
+            {
+              type: "symlink",
+              name: "file-link",
+              linkname: "file",
+              date: testDate,
+            },
+            (err) => {
+              if (err) throw err;
+              archive.entry(
+                null,
+                {
+                  type: "symlink",
+                  name: "file-link-2",
+                  linkname: "file",
+                  date: testDate,
+                  mode: 420,
+                },
+                (err) => {
+                  if (err) throw err;
+                  archive.finalize();
+                },
+              );
+            },
+          );
+        });
+      });
+    });
+
+    it("should support appending forward slash to entry names", async () => {
+      await new Promise<void>((resolve) => {
+        const archive = new Packer({
+          namePrependSlash: true,
+        });
+        const testStream = createWriteStream("tmp/name-prepend-slash.zip");
+        testStream.on("close", () => {
+          resolve();
+        });
+        archive.pipe(testStream);
+        archive.entry(
+          "some text",
+          { name: "file", namePrependSlash: false, date: testDate },
+          (err) => {
+            if (err) throw err;
+            archive.entry(
+              "more text",
+              { type: "file", name: "file-with-prefix", date: testDate },
+              (err) => {
+                if (err) throw err;
+                archive.finalize();
+              },
+            );
+          },
+        );
+      });
     });
   });
 });

--- a/packages/zip-stream/tests/utils.test.ts
+++ b/packages/zip-stream/tests/utils.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 
 import { dateify, sanitizePath } from "../src/utils";
 
@@ -8,35 +9,44 @@ const testDate = new Date(testDateString);
 describe("utils", () => {
   describe("dateify(dateish)", () => {
     it("should return an instance of Date", () => {
-      expect(dateify(testDate)).toBeInstanceOf(Date);
-      expect(dateify(testDateString)).toBeInstanceOf(Date);
-      expect(dateify(null)).toBeInstanceOf(Date);
+      assert.ok(dateify(testDate) instanceof Date);
+      assert.ok(dateify(testDateString) instanceof Date);
+      assert.ok(dateify(null) instanceof Date);
     });
 
     it("should passthrough an instance of Date", () => {
-      expect(dateify(testDate)).toEqual(testDate);
+      assert.deepStrictEqual(dateify(testDate), testDate);
     });
 
     it("should convert dateish string to an instance of Date", () => {
-      expect(dateify(testDateString)).toEqual(testDate);
+      assert.deepStrictEqual(dateify(testDateString), testDate);
     });
   });
 
   describe("sanitizePath(filepath)", () => {
     it("should sanitize filepath", () => {
-      expect(sanitizePath("\\this/path//file.txt")).toBe("this/path/file.txt");
-      expect(sanitizePath("/this/path/file.txt")).toBe("this/path/file.txt");
-      expect(sanitizePath("./this\\path\\file.txt")).toBe(
+      assert.strictEqual(
+        sanitizePath("\\this/path//file.txt"),
+        "this/path/file.txt",
+      );
+      assert.strictEqual(
+        sanitizePath("/this/path/file.txt"),
+        "this/path/file.txt",
+      );
+      assert.strictEqual(
+        sanitizePath("./this\\path\\file.txt"),
         "./this/path/file.txt",
       );
-      expect(sanitizePath("../this\\path\\file.txt")).toBe(
+      assert.strictEqual(
+        sanitizePath("../this\\path\\file.txt"),
         "this/path/file.txt",
       );
 
-      expect(sanitizePath("c:\\this\\path\\file.txt")).toBe(
+      assert.strictEqual(
+        sanitizePath("c:\\this\\path\\file.txt"),
         "this/path/file.txt",
       );
-      expect(sanitizePath("\\\\server\\share\\")).toBe("server/share/");
+      assert.strictEqual(sanitizePath("\\\\server\\share\\"), "server/share/");
     });
   });
 });


### PR DESCRIPTION
Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Migrated tests from Bun to Node’s built-in test runner; replaced matcher assertions with Node strict asserts and converted callback-based tests to async/await Promises.

* **Chores**
  * Updated test lifecycle/setup patterns for Node compatibility across packages.

* **New Features**
  * Public glob constructor/factory now accept a false value for the working-directory parameter (treated as current directory).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->