### PR TITLE
chore: simplify `directory` method, avoid glob

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,6 @@
       "name": "@archiver/archiver",
       "version": "0.2.0",
       "dependencies": {
-        "@archiver/readdir-glob": "workspace:*",
         "@archiver/tar-stream": "workspace:*",
         "@archiver/zip-stream": "workspace:*",
       },

--- a/packages/archiver/package.json
+++ b/packages/archiver/package.json
@@ -25,7 +25,6 @@
     "prepublishOnly": "bun run build"
   },
   "dependencies": {
-    "@archiver/readdir-glob": "workspace:*",
     "@archiver/tar-stream": "workspace:*",
     "@archiver/zip-stream": "workspace:*"
   },

--- a/packages/archiver/src/lib/core.ts
+++ b/packages/archiver/src/lib/core.ts
@@ -598,6 +598,62 @@ class Archiver extends Transform {
   }
 
   /**
+   * Processes a single filesystem entry within a directory traversal.
+   */
+  private async _processDirectoryEntry(
+    entry: fs.Dirent,
+    rootDir: string,
+    dirpath: string,
+    destpath: string,
+    baseData: EntryData,
+    dataFunction: ((entryData: EntryData) => EntryData | false) | null,
+  ): Promise<void> {
+    const absolutePath = path.join(entry.parentPath, entry.name);
+    const relativePath = path
+      .relative(rootDir, absolutePath)
+      .replace(/\\/g, "/");
+
+    const stats = await fs.promises.lstat(absolutePath);
+
+    let ignoreMatch = false;
+    let entryData: EntryData = { ...baseData };
+
+    entryData.name = relativePath;
+    entryData.prefix = destpath;
+    entryData.stats = stats;
+
+    return new Promise<void>((resolve) => {
+      entryData.callback = resolve;
+
+      try {
+        if (dataFunction) {
+          const res = dataFunction(entryData);
+          if (res === false) {
+            ignoreMatch = true;
+          } else if (typeof res !== "object") {
+            throw new ArchiverError("DIRECTORYFUNCTIONINVALIDDATA", {
+              dirpath: dirpath,
+            });
+          } else {
+            entryData = res;
+          }
+        }
+      } catch (e) {
+        this.emit("error", e);
+        resolve();
+        return;
+      }
+
+      if (ignoreMatch) {
+        resolve();
+        return;
+      }
+
+      this._append(absolutePath, entryData);
+    });
+  }
+
+  /**
    * Appends a directory and its files, recursively, given its dirpath.
    */
   directory(
@@ -634,49 +690,14 @@ class Archiver extends Transform {
         for (const entry of entries) {
           if (this._state.aborted) break;
 
-          const absolutePath = path.join(entry.parentPath, entry.name);
-          const relativePath = path
-            .relative(rootDir, absolutePath)
-            .replace(/\\/g, "/");
-
-          const stats = await fs.promises.lstat(absolutePath);
-
-          let ignoreMatch = false;
-          let entryData: EntryData = { ...baseData };
-
-          entryData.name = relativePath;
-          entryData.prefix = destpath;
-          entryData.stats = stats;
-
-          await new Promise<void>((resolve) => {
-            entryData.callback = resolve;
-
-            try {
-              if (dataFunction) {
-                const res = dataFunction(entryData);
-                if (res === false) {
-                  ignoreMatch = true;
-                } else if (typeof res !== "object") {
-                  throw new ArchiverError("DIRECTORYFUNCTIONINVALIDDATA", {
-                    dirpath: dirpath,
-                  });
-                } else {
-                  entryData = res;
-                }
-              }
-            } catch (e) {
-              this.emit("error", e);
-              resolve();
-              return;
-            }
-
-            if (ignoreMatch) {
-              resolve();
-              return;
-            }
-
-            this._append(absolutePath, entryData);
-          });
+          await this._processDirectoryEntry(
+            entry,
+            rootDir,
+            dirpath,
+            destpath,
+            baseData,
+            dataFunction,
+          );
         }
       } catch (err) {
         this.emit("error", err);

--- a/packages/archiver/src/lib/core.ts
+++ b/packages/archiver/src/lib/core.ts
@@ -7,7 +7,6 @@ import {
   PassThrough,
 } from "node:stream";
 
-import { readdirGlob } from "@archiver/readdir-glob";
 import { dateify, sanitizePath, isStream } from "@archiver/zip-stream/utils";
 
 import { queue } from "./async/index.ts";
@@ -620,60 +619,73 @@ class Archiver extends Transform {
     } else if (typeof destpath !== "string") {
       destpath = dirpath;
     }
-    let dataFunction = null;
-    if (typeof data === "function") {
-      dataFunction = data;
-      data = {};
-    } else if (typeof data !== "object") {
-      data = {};
-    }
-    const globOptions = {
-      stat: true,
-      dot: true,
-    };
-    function onGlobEnd() {
-      this._pending--;
-      this._maybeFinalize();
-    }
-    function onGlobError(err) {
-      this.emit("error", err);
-    }
-    function onGlobMatch(match) {
-      globber.pause();
-      let ignoreMatch = false;
-      let entryData = Object.assign({}, data);
 
-      entryData.name = match.relative;
-      entryData.prefix = destpath;
-      entryData.stats = match.stat;
-      entryData.callback = globber.resume.bind(globber);
+    const dataFunction = typeof data === "function" ? data : null;
+    const baseData = typeof data === "object" ? data : {};
 
+    (async () => {
       try {
-        if (dataFunction) {
-          entryData = dataFunction(entryData);
-          if (entryData === false) {
-            ignoreMatch = true;
-          } else if (typeof entryData !== "object") {
-            throw new ArchiverError("DIRECTORYFUNCTIONINVALIDDATA", {
-              dirpath: dirpath,
-            });
-          }
-        }
-      } catch (e) {
-        this.emit("error", e);
-        return;
-      }
-      if (ignoreMatch) {
-        globber.resume();
-        return;
-      }
-      this._append(match.absolute, entryData);
-    }
+        const rootDir = path.resolve(dirpath);
+        const entries = await fs.promises.readdir(rootDir, {
+          recursive: true,
+          withFileTypes: true,
+        });
 
-    const globber = readdirGlob(dirpath, globOptions);
-    globber.on("error", onGlobError.bind(this));
-    globber.on("match", onGlobMatch.bind(this));
-    globber.on("end", onGlobEnd.bind(this));
+        for (const entry of entries) {
+          if (this._state.aborted) break;
+
+          const absolutePath = path.join(entry.parentPath, entry.name);
+          const relativePath = path
+            .relative(rootDir, absolutePath)
+            .replace(/\\/g, "/");
+
+          const stats = await fs.promises.lstat(absolutePath);
+
+          let ignoreMatch = false;
+          let entryData: EntryData = { ...baseData };
+
+          entryData.name = relativePath;
+          entryData.prefix = destpath;
+          entryData.stats = stats;
+
+          await new Promise<void>((resolve) => {
+            entryData.callback = resolve;
+
+            try {
+              if (dataFunction) {
+                const res = dataFunction(entryData);
+                if (res === false) {
+                  ignoreMatch = true;
+                } else if (typeof res !== "object") {
+                  throw new ArchiverError("DIRECTORYFUNCTIONINVALIDDATA", {
+                    dirpath: dirpath,
+                  });
+                } else {
+                  entryData = res;
+                }
+              }
+            } catch (e) {
+              this.emit("error", e);
+              resolve();
+              return;
+            }
+
+            if (ignoreMatch) {
+              resolve();
+              return;
+            }
+
+            this._append(absolutePath, entryData);
+          });
+        }
+      } catch (err) {
+        this.emit("error", err);
+      } finally {
+        this._pending--;
+        this._maybeFinalize();
+      }
+    })();
+
     return this;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directory archiving now supports recursive processing with per-entry filtering and customization.
  * Entries can be skipped by returning `false` from the entry callback.
  * Directory destinations may be omitted when only entry-level handling is needed.
  * Improved support for aborting directory processing and reporting errors asynchronously.
* **Improvements**
  * Directory traversal is more reliable and no longer depends on the previous glob-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->