### PR TITLE
feat!: remove `.glob` method

### DIFF
--- a/packages/archiver/src/lib/core.ts
+++ b/packages/archiver/src/lib/core.ts
@@ -51,10 +51,6 @@ interface EntryData {
   stats?: fs.Stats;
 }
 
-interface GlobOptions {
-  cwd: string;
-}
-
 function normalizeEntryData(data: EntryData, stats?: fs.Stats): EntryData {
   const normalizedData = {
     type: "file",
@@ -696,34 +692,6 @@ class Archiver extends Transform {
       return this;
     }
     this._append(filepath, data);
-    return this;
-  }
-
-  /**
-   * Appends multiple files that match a glob pattern.
-   */
-  glob(pattern: string, options: GlobOptions, data: EntryData): this {
-    this._pending++;
-    options = { stat: true, pattern, ...options };
-    function onGlobEnd() {
-      this._pending--;
-      this._maybeFinalize();
-    }
-    function onGlobError(err) {
-      this.emit("error", err);
-    }
-    function onGlobMatch(match) {
-      globber.pause();
-      const entryData = Object.assign({}, data);
-      entryData.callback = globber.resume.bind(globber);
-      entryData.stats = match.stat;
-      entryData.name = match.relative;
-      this._append(match.absolute, entryData);
-    }
-    const globber = readdirGlob(options.cwd || ".", options);
-    globber.on("error", onGlobError.bind(this));
-    globber.on("match", onGlobMatch.bind(this));
-    globber.on("end", onGlobEnd.bind(this));
     return this;
   }
 

--- a/packages/archiver/tests/archiver.test.ts
+++ b/packages/archiver/tests/archiver.test.ts
@@ -347,47 +347,6 @@ describe("archiver", () => {
       });
     });
 
-    describe("#glob", () => {
-      let actual;
-      let archive;
-      const entries = {};
-
-      before(async () => {
-        archive = new JsonArchive();
-        await new Promise<void>((resolve) => {
-          const testStream = createWriteStream("tmp/glob.json");
-          testStream.on("close", () => {
-            actual = readJSON("tmp/glob.json");
-            actual.forEach((entry) => {
-              entries[entry.name] = entry;
-            });
-            resolve();
-          });
-          archive.pipe(testStream);
-          archive
-            .glob("tests/fixtures/test.txt", null)
-            .glob("tests/fixtures/empty.txt", null)
-            .glob("tests/fixtures/executable.sh", null)
-            .glob("tests/fixtures/directory/**/*", {
-              ignore: "tests/fixtures/directory/subdir/**/*",
-              nodir: true,
-            })
-            .glob("**/*", { cwd: "tests/fixtures/directory/subdir/" })
-            .finalize();
-        });
-      });
-
-      it("should append multiple entries", () => {
-        assert.ok(Array.isArray(actual));
-        assert.ok("tests/fixtures/test.txt" in entries);
-        assert.ok("tests/fixtures/executable.sh" in entries);
-        assert.ok("tests/fixtures/empty.txt" in entries);
-        assert.ok("tests/fixtures/directory/level0.txt" in entries);
-        assert.ok("level1.txt" in entries);
-        assert.ok("subsub/level2.txt" in entries);
-      });
-    });
-
     describe("#promise", () => {
       it("should use a promise", async () => {
         const archive = new JsonArchive();


### PR DESCRIPTION
Closes #28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the archiver’s public globbing method and related configuration.
  * File matching via glob patterns is no longer supported through the archiver API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->